### PR TITLE
[WIP] Take CFP from r15

### DIFF
--- a/iseq.c
+++ b/iseq.c
@@ -3396,7 +3396,7 @@ trace_set_i(void *vstart, void *vend, size_t stride, void *data)
 }
 
 void
-rb_yjit_empty_func_with_ec(rb_control_frame_t *cfp, rb_execution_context_t *ec)
+rb_yjit_empty_func_with_ec(rb_execution_context_t *ec, rb_control_frame_t *cfp)
 {
     // it's put in this file instead of say, compile.c to dodge long C compile time.
     // it just needs to be in a different unit from vm.o so the compiler can't see the definition

--- a/iseq.h
+++ b/iseq.h
@@ -301,7 +301,7 @@ VALUE rb_iseq_defined_string(enum defined_type type);
 /* vm.c */
 VALUE rb_iseq_local_variables(const rb_iseq_t *iseq);
 
-NOINLINE(void rb_yjit_empty_func_with_ec(rb_control_frame_t *cfp, rb_execution_context_t *ec));
+NOINLINE(void rb_yjit_empty_func_with_ec(rb_execution_context_t *ec, rb_control_frame_t *cfp));
 
 RUBY_SYMBOL_EXPORT_END
 

--- a/tool/ruby_vm/views/vm.inc.erb
+++ b/tool/ruby_vm/views/vm.inc.erb
@@ -32,7 +32,7 @@ INSN_ENTRY(yjit_call_example_with_ec)
 #if USE_MACHINE_REGS
     // assumes USE_MACHINE_REGS, aka reg_pc setup,
     // aka #define SET_PC(x) (reg_cfp->pc = reg_pc = (x))
-    rb_yjit_empty_func_with_ec(GET_CFP(), ec);
+    rb_yjit_empty_func_with_ec(ec, GET_CFP());
     RESTORE_REGS();
 #endif
     END_INSN(yjit_call_example_with_ec);

--- a/yjit_core.h
+++ b/yjit_core.h
@@ -5,7 +5,7 @@
 #include "yjit_asm.h"
 
 // Register YJIT receives the CFP and EC into
-#define REG_CFP RDI
+#define REG_CFP R15
 #define REG_EC RSI
 
 // Register YJIT loads the SP into

--- a/yjit_core.h
+++ b/yjit_core.h
@@ -6,7 +6,7 @@
 
 // Register YJIT receives the CFP and EC into
 #define REG_CFP R15
-#define REG_EC RSI
+#define REG_EC RDI
 
 // Register YJIT loads the SP into
 #define REG_SP RDX


### PR DESCRIPTION
YARV with reg_cfp enabled already pins the CFP into R15 so I think we can continue that convention int YJIT and skip making the cfp a parameter for the fake call.