### PR TITLE
Add timeout for test-all tests

### DIFF
--- a/tool/lib/test/unit.rb
+++ b/tool/lib/test/unit.rb
@@ -9,6 +9,7 @@ require_relative '../envutil'
 require_relative '../colorize'
 require 'test/unit/testcase'
 require 'optparse'
+require 'timeout'
 
 # See Test::Unit
 module Test
@@ -1281,7 +1282,9 @@ class MiniTest::Unit::TestCase # :nodoc: all
   RUN_TEST_TRACE = "#{__FILE__}:#{__LINE__+3}:in `run_test'".freeze
   def run_test(name)
     progname, $0 = $0, "#{$0}: #{self.class}##{name}"
-    self.__send__(name)
+    Timeout.timeout(5 * 60) do # To catch hanging tests
+      self.__send__(name)
+    end
   ensure
     $@.delete(RUN_TEST_TRACE) if $@
     $0 = progname


### PR DESCRIPTION
Sometimes our CI timeout due to tests hanging. Set a timeout for tests
using the Timeout stdlib. The caveat is that if the test that hangs
doesn't check for Ruby interrupts the Timeout library might be
ineffective. Let's see put this on CI and see how it goes.