### PR TITLE
Add timeout for test-all tests when using parallel runner

### DIFF
--- a/tool/lib/minitest/unit.rb
+++ b/tool/lib/minitest/unit.rb
@@ -1314,6 +1314,9 @@ module MiniTest
 
         begin
           @passed = nil
+          if defined?(on_parallel_worker?) && on_parallel_worker?
+            runner.before_test_start(self.class, self.__name__)
+          end
           self.before_setup
           self.setup
           self.after_setup


### PR DESCRIPTION
Sometimes our CI timeout due to tests hanging. Set a timeout for tests
using the Timeout stdlib. The caveat is that if the test that hangs
doesn't check for Ruby interrupts the Timeout library might be
ineffective. Let's see put this on CI and see how it goes.

Pretty hacky code, I know, but hopefully it doesn't make CI less stable?
I tried using the Timeout stdlib at first, but some tests that look at
the backtrace fail if I wrap them in `Timeout.timeout`.

Alternative would be to just log the test names before running them, but
that would generate a lot of log data. Don't like that.