### PR TITLE
Merge upstream commits

### DIFF
--- a/dln.c
+++ b/dln.c
@@ -312,7 +312,7 @@ dln_load(const char *file)
     HINSTANCE handle;
     WCHAR *winfile;
     char message[1024];
-    void (*init_fct)();
+    void (*init_fct)(void);
     char *buf;
 
     /* Load the file as an object one */
@@ -341,7 +341,7 @@ dln_load(const char *file)
     }
 #endif
 
-    if ((init_fct = (void(*)())GetProcAddress(handle, buf)) == NULL) {
+    if ((init_fct = (void(*)(void))GetProcAddress(handle, buf)) == NULL) {
 	dln_loaderror("%s - %s\n%s", dln_strerror(), buf, file);
     }
 
@@ -358,7 +358,7 @@ dln_load(const char *file)
 #define DLN_DEFINED
     {
 	void *handle;
-	void (*init_fct)();
+	void (*init_fct)(void);
 
 #ifndef RTLD_LAZY
 # define RTLD_LAZY 1
@@ -393,7 +393,7 @@ dln_load(const char *file)
 	}
 # endif
 
-	init_fct = (void(*)())(VALUE)dlsym(handle, buf);
+	init_fct = (void(*)(void))(VALUE)dlsym(handle, buf);
 	if (init_fct == NULL) {
 	    const size_t errlen = strlen(error = dln_strerror()) + 1;
 	    error = memcpy(ALLOCA_N(char, errlen), error, errlen);
@@ -412,7 +412,7 @@ dln_load(const char *file)
     {
 	shl_t lib = NULL;
 	int flags;
-	void (*init_fct)();
+	void (*init_fct)(void);
 
 	flags = BIND_DEFERRED;
 	lib = shl_load(file, flags, 0);
@@ -436,9 +436,9 @@ dln_load(const char *file)
 #if defined(_AIX)
 #define DLN_DEFINED
     {
-	void (*init_fct)();
+	void (*init_fct)(void);
 
-	init_fct = (void(*)())load((char*)file, 1, 0);
+	init_fct = (void(*)(void))load((char*)file, 1, 0);
 	if (init_fct == NULL) {
 	    aix_loaderror(file);
 	}
@@ -467,7 +467,7 @@ dln_load(const char *file)
 	/* "file" is module file name .
 	   "buf" is pointer to initial function name with "_" . */
 
-	void (*init_fct)();
+	void (*init_fct)(void);
 
 
 	dyld_result = NSCreateObjectFileImageFromFile(file, &obj_file);

--- a/eval_jump.c
+++ b/eval_jump.c
@@ -48,7 +48,7 @@ rb_f_at_exit(VALUE _)
 }
 
 struct end_proc_data {
-    void (*func) ();
+    void (*func) (VALUE);
     VALUE data;
     struct end_proc_data *next;
 };

--- a/gc.c
+++ b/gc.c
@@ -570,7 +570,8 @@ struct RPayload {
 };
 #define RPAYLOAD(obj) ((struct RPayload *)obj)
 static unsigned short
-RPAYLOAD_LEN(VALUE obj) {
+RPAYLOAD_LEN(VALUE obj)
+{
     unsigned short len = (unsigned short)(RPAYLOAD(obj)->flags >> FL_USHIFT);
     return len;
 }
@@ -1302,7 +1303,8 @@ payload_or_self(VALUE obj)
                 return cur;
             }
             cur += RPAYLOAD_LEN(cur) * sizeof(RVALUE);
-        } else {
+        }
+        else {
             cur += sizeof(RVALUE);
         }
         if (poisoned) {
@@ -2275,6 +2277,7 @@ rvargc_slot_count(size_t size)
     return roomof(size + sizeof(struct RPayload), sizeof(RVALUE));
 }
 
+#if USE_RVARGC
 static RVALUE *
 rvargc_find_contiguous_slots(int slots, RVALUE *freelist)
 {
@@ -2289,14 +2292,16 @@ rvargc_find_contiguous_slots(int slots, RVALUE *freelist)
             // Peek ahead to see if the region is contiguous
             if (search->as.free.next == (search - 1)) {
                 search = search->as.free.next;
-            } else {
+            }
+            else {
                 // Next slot is not contiguous
                 if (search->as.free.next) {
                     cursor = search->as.free.next;
                     previous_region = search;
 
                     break;
-                } else {
+                }
+                else {
                     // Hit the end of the free list
                     return NULL;
                 }
@@ -2313,11 +2318,13 @@ rvargc_find_contiguous_slots(int slots, RVALUE *freelist)
     }
     rb_bug("rvargc_find_contiguous_slots: unreachable");
 }
+#endif
 
 static inline bool heap_add_freepage(rb_heap_t *heap, struct heap_page *page);
 static struct heap_page * heap_next_freepage(rb_objspace_t *objspace, rb_heap_t *heap);
 static inline void ractor_set_cache(rb_ractor_t *cr, struct heap_page *page);
 
+#if USE_RVARGC
 static inline void *
 rvargc_find_region(size_t size, rb_ractor_t *cr, RVALUE *freelist)
 {
@@ -2372,9 +2379,10 @@ rvargc_find_region(size_t size, rb_ractor_t *cr, RVALUE *freelist)
     }
     return NULL;
 }
+#endif
 
 int
-rb_slot_size()
+rb_slot_size(void)
 {
     return sizeof(RVALUE);
 }
@@ -4584,7 +4592,7 @@ obj_memsize_of(VALUE obj, int use_all_types)
       case T_HASH:
         if (RHASH_AR_TABLE_P(obj)) {
             if (RHASH_AR_TABLE(obj) != NULL) {
-                size_t rb_hash_ar_table_size();
+                size_t rb_hash_ar_table_size(void);
                 size += rb_hash_ar_table_size();
             }
 	}
@@ -4779,7 +4787,8 @@ count_objects(int argc, VALUE *argv, VALUE os)
             if (RB_TYPE_P(vp, T_PAYLOAD)) {
                 stride = RPAYLOAD_LEN(vp);
                 counts[BUILTIN_TYPE(vp)] += RPAYLOAD_LEN(vp);
-            } else
+            }
+            else
 #endif
             if (p->as.basic.flags) {
                 counts[BUILTIN_TYPE(vp)]++;
@@ -5465,7 +5474,8 @@ gc_sweep_start_heap(rb_objspace_t *objspace, rb_heap_t *heap)
                 }
                 p->as.free.next = freelist;
                 asan_poison_object((VALUE)p);
-            } else {
+            }
+            else {
                 page->freelist = freelist;
             }
             asan_poison_memory_region(&page->freelist, sizeof(RVALUE*));
@@ -7454,7 +7464,8 @@ gc_verify_heap_page(rb_objspace_t *objspace, struct heap_page *page, VALUE obj)
 #if USE_RVARGC
         if (BUILTIN_TYPE(val) == T_PAYLOAD) {
             stride = RPAYLOAD_LEN(val);
-        } else {
+        }
+        else {
             stride = default_stride;
         }
 #endif

--- a/hash.c
+++ b/hash.c
@@ -4820,7 +4820,7 @@ extern char **environ;
 #endif
 
 static inline rb_encoding *
-env_encoding()
+env_encoding(void)
 {
 #ifdef _WIN32
     return rb_utf8_encoding();

--- a/include/ruby/thread_native.h
+++ b/include/ruby/thread_native.h
@@ -47,7 +47,7 @@ typedef pthread_cond_t rb_nativethread_cond_t;
 
 RUBY_SYMBOL_EXPORT_BEGIN
 
-rb_nativethread_id_t rb_nativethread_self();
+rb_nativethread_id_t rb_nativethread_self(void);
 
 void rb_nativethread_lock_initialize(rb_nativethread_lock_t *lock);
 void rb_nativethread_lock_destroy(rb_nativethread_lock_t *lock);

--- a/internal/gc.h
+++ b/internal/gc.h
@@ -114,7 +114,7 @@ void rb_gc_mark_vm_stack_values(long n, const VALUE *values);
 void *ruby_sized_xrealloc(void *ptr, size_t new_size, size_t old_size) RUBY_ATTR_RETURNS_NONNULL RUBY_ATTR_ALLOC_SIZE((2));
 void *ruby_sized_xrealloc2(void *ptr, size_t new_count, size_t element_size, size_t old_count) RUBY_ATTR_RETURNS_NONNULL RUBY_ATTR_ALLOC_SIZE((2, 3));
 void ruby_sized_xfree(void *x, size_t size);
-int rb_slot_size();
+int rb_slot_size(void);
 RUBY_SYMBOL_EXPORT_END
 
 MJIT_SYMBOL_EXPORT_BEGIN

--- a/misc/lldb_cruby.py
+++ b/misc/lldb_cruby.py
@@ -545,12 +545,9 @@ class HeapPageIter:
     def is_valid(self):
         heap_page_header_size = self.target.FindFirstType("struct heap_page_header").GetByteSize()
         rvalue_size = self.tRValue.GetByteSize()
-        heap_page_obj_limit = (HEAP_PAGE_SIZE - heap_page_header_size)/rvalue_size
+        heap_page_obj_limit = int((HEAP_PAGE_SIZE - heap_page_header_size) / rvalue_size)
 
-        if (self.num_slots > heap_page_obj_limit) or (self.num_slots < heap_page_obj_limit - 1):
-            return False
-        else:
-            return True
+        return (heap_page_obj_limit - 1) <= self.num_slots <= heap_page_obj_limit
 
     def __iter__(self):
         return self

--- a/thread_pthread.h
+++ b/thread_pthread.h
@@ -102,7 +102,7 @@ RUBY_SYMBOL_EXPORT_BEGIN
 #ifdef RB_THREAD_LOCAL_SPECIFIER
   #ifdef __APPLE__
     // on Darwin, TLS can not be accessed across .so
-    struct rb_execution_context_struct *rb_current_ec();
+    struct rb_execution_context_struct *rb_current_ec(void);
     void rb_current_ec_set(struct rb_execution_context_struct *);
   #else
     RUBY_EXTERN RB_THREAD_LOCAL_SPECIFIER struct rb_execution_context_struct *ruby_current_ec;

--- a/version.h
+++ b/version.h
@@ -16,7 +16,7 @@
 
 #define RUBY_RELEASE_YEAR 2021
 #define RUBY_RELEASE_MONTH 5
-#define RUBY_RELEASE_DAY 6
+#define RUBY_RELEASE_DAY 7
 
 #include "ruby/version.h"
 

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -1864,7 +1864,7 @@ vm_search_method(VALUE cd_owner, struct rb_call_data *cd, VALUE recv)
 }
 
 static inline int
-check_cfunc(const rb_callable_method_entry_t *me, VALUE (*func)())
+check_cfunc(const rb_callable_method_entry_t *me, VALUE (*func)(ANYARGS))
 {
     if (! me) {
         return false;
@@ -1883,7 +1883,7 @@ check_cfunc(const rb_callable_method_entry_t *me, VALUE (*func)())
 }
 
 static inline int
-vm_method_cfunc_is(const rb_iseq_t *iseq, CALL_DATA cd, VALUE recv, VALUE (*func)())
+vm_method_cfunc_is(const rb_iseq_t *iseq, CALL_DATA cd, VALUE recv, VALUE (*func)(ANYARGS))
 {
     VM_ASSERT(iseq != NULL);
     const struct rb_callcache *cc = vm_search_method((VALUE)iseq, cd, recv);

--- a/vm_method.c
+++ b/vm_method.c
@@ -436,7 +436,7 @@ static VALUE
 }
 
 static void
-setup_method_cfunc_struct(rb_method_cfunc_t *cfunc, VALUE (*func)(), int argc)
+setup_method_cfunc_struct(rb_method_cfunc_t *cfunc, VALUE (*func)(ANYARGS), int argc)
 {
     cfunc->func = func;
     cfunc->argc = argc;

--- a/vsnprintf.c
+++ b/vsnprintf.c
@@ -166,6 +166,8 @@ struct __sbuf {
  *
  * NB: see WARNING above before changing the layout of this structure!
  */
+struct __suio;
+
 typedef	struct __sFILE {
 	unsigned char *_p;	/* current position in (some) buffer */
 #if 0
@@ -178,8 +180,8 @@ typedef	struct __sFILE {
 #if 0
 	size_t	_lbfsize;	/* 0 or -_bf._size, for inline putc */
 #endif
-	int	(*vwrite)(/* struct __sFILE*, struct __suio * */);
-	const char *(*vextra)(/* struct __sFILE*, size_t, void*, long*, int */);
+	int	(*vwrite)(struct __sFILE*, struct __suio *);
+	const char *(*vextra)(struct __sFILE*, size_t, void*, long*, int);
 } FILE;
 
 


### PR DESCRIPTION
We ought to not squash commits when merging from upstream, or else we end up with the same file contents as upstream but different history. The list of commits we merge each time becomes unclear, too.