### PR TITLE
Guard for T_OBJECT at compile time

### DIFF
--- a/yjit_codegen.c
+++ b/yjit_codegen.c
@@ -1012,7 +1012,8 @@ gen_get_ivar(jitstate_t *jit, ctx_t *ctx, const int max_chain_depth, VALUE compt
     // NOTE: This assumes nobody changes the allocator of the class after allocation.
     //       Eventually, we can encode whether an object is T_OBJECT or not
     //       inside object shapes.
-    if (rb_get_alloc_func(comptime_val_klass) != rb_class_allocate_instance) {
+    if (!RB_TYPE_P(comptime_receiver, T_OBJECT) ||
+            rb_get_alloc_func(comptime_val_klass) != rb_class_allocate_instance) {
         // General case. Call rb_ivar_get(). No need to reconstruct interpreter
         // state since the routine never raises exceptions or allocate objects
         // visibile to Ruby.


### PR DESCRIPTION
Previously this could crash on Nokogiri when JITing the getivar instruction because we would attempt to treat Nokogiri::XML::Document's T_DATA as a T_OBJECT in calling rb_iv_index_tbl_lookup.

This commit also checks for T_OBJECT at compile time and emits the rb_ivar_get fallback in that case.

The crash we observed was in [Nokogiri::XML::Document#decorate](https://github.com/sparklemotion/nokogiri/blob/ce7e7b598feca8bf537edf49fb80499e24c91cbe/lib/nokogiri/xml/document.rb#L283), but were able to reduce the repro to this script:

```
require "nokogiri"

Nokogiri::XML::Document.class_eval do
  def has_decorators?
    @decorators
  end
end

puts Nokogiri::HTML("").has_decorators?
puts Nokogiri::HTML("").has_decorators?
```