### PR TITLE
Detect true/false/nil/other types in YJIT branches when possible

### DIFF
--- a/yjit_codegen.c
+++ b/yjit_codegen.c
@@ -120,8 +120,12 @@ jit_type_of_value(VALUE val)
     if (SPECIAL_CONST_P(val)) {
         if (FIXNUM_P(val)) {
             return TYPE_FIXNUM;
-        } else if (NIL_P(val)) {
+        } else if (val == Qnil) {
             return TYPE_NIL;
+        } else if (val == Qtrue) {
+            return TYPE_TRUE;
+        } else if (val == Qfalse) {
+            return TYPE_FALSE;
         } else {
             // generic immediate
             return TYPE_IMM;
@@ -678,7 +682,7 @@ gen_putobject(jitstate_t* jit, ctx_t* ctx)
     }
     else if (arg == Qtrue || arg == Qfalse)
     {
-        x86opnd_t stack_top = ctx_stack_push(ctx, TYPE_IMM);
+        x86opnd_t stack_top = ctx_stack_push(ctx, jit_type_of_value(arg));
         mov(cb, stack_top, imm_opnd((int64_t)arg));
     }
     else

--- a/yjit_core.h
+++ b/yjit_core.h
@@ -32,6 +32,8 @@ enum yjit_type_enum
 {
     ETYPE_UNKNOWN = 0,
     ETYPE_NIL,
+    ETYPE_TRUE,
+    ETYPE_FALSE,
     ETYPE_FIXNUM,
     ETYPE_ARRAY,
     ETYPE_HASH,
@@ -49,7 +51,7 @@ typedef struct yjit_type_struct
     uint8_t is_imm : 1;
 
     // Specific value type, if known
-    uint8_t type : 3;
+    uint8_t type : 4;
 
 } val_type_t;
 STATIC_ASSERT(val_type_size, sizeof(val_type_t) == 1);
@@ -64,6 +66,8 @@ STATIC_ASSERT(val_type_size, sizeof(val_type_t) == 1);
 #define TYPE_IMM ( (val_type_t){ .is_imm = 1 } )
 
 #define TYPE_NIL ( (val_type_t){ .is_imm = 1, .type = ETYPE_NIL } )
+#define TYPE_TRUE ( (val_type_t){ .is_imm = 1, .type = ETYPE_TRUE } )
+#define TYPE_FALSE ( (val_type_t){ .is_imm = 1, .type = ETYPE_FALSE } )
 #define TYPE_FIXNUM ( (val_type_t){ .is_imm = 1, .type = ETYPE_FIXNUM } )
 #define TYPE_ARRAY ( (val_type_t){ .is_heap = 1, .type = ETYPE_ARRAY } )
 #define TYPE_HASH ( (val_type_t){ .is_heap = 1, .type = ETYPE_HASH } )


### PR DESCRIPTION
Somewhat of a follow up to #57, where I added ETYPE_TRUE and ETYPE_FALSE

This adds checks on types to gen_branchnil/gen_branchif/gen_branchunless. Any time we don't have ETYPE_UNKNOWN we should have enough info to emit a direct jump.

This also adds checking for `Qtrue`/`Qfalse` in putobject and getinlinecache.

I saw the commented out `TEMP_CONST` in `enum yjit_temp_loc`, which this seems like it could be a fit for (and possibly avoid pushing true/false just to immediately pop it), but didn't dig much further.