### PR TITLE
Use builtin_inline_p to skip a frame of C methods

### DIFF
--- a/yjit_iface.c
+++ b/yjit_iface.c
@@ -126,19 +126,6 @@ check_cfunc_dispatch(VALUE receiver, struct rb_callinfo *ci, void *callee, rb_ca
 
 MJIT_FUNC_EXPORTED VALUE rb_hash_has_key(VALUE hash, VALUE key);
 
-bool
-cfunc_needs_frame(const rb_method_cfunc_t *cfunc)
-{
-    void* fptr = (void*)cfunc->func;
-
-    // Leaf C functions do not need a stack frame
-    // or a stack overflow check
-    return !(
-        // Hash#key?
-        fptr == (void*)rb_hash_has_key
-    );
-}
-
 // GC root for interacting with the GC
 struct yjit_root_struct {
     int unused; // empty structs are not legal in C99

--- a/yjit_iface.h
+++ b/yjit_iface.h
@@ -100,7 +100,6 @@ VALUE *yjit_iseq_pc_at_idx(const rb_iseq_t *iseq, uint32_t insn_idx);
 int yjit_opcode_at_pc(const rb_iseq_t *iseq, const VALUE *pc);
 
 void check_cfunc_dispatch(VALUE receiver, struct rb_callinfo *ci, void *callee, rb_callable_method_entry_t *compile_time_cme);
-bool cfunc_needs_frame(const rb_method_cfunc_t *cfunc);
 
 RBIMPL_ATTR_NODISCARD() bool assume_bop_not_redefined(block_t *block, int redefined_flag, enum ruby_basic_operators bop);
 void assume_method_lookup_stable(VALUE receiver_klass, const rb_callable_method_entry_t *cme, block_t *block);


### PR DESCRIPTION
In CRuby, we're trying to annotate C methods that don't need a stack frame by `Primitive.attr! 'inline'`. Instead of hard-coding such a list of C methods in `cfunc_needs_frame`, this PR implements the same optimization using the annotation. 

If you use this annotation to implement the optimization, CI will automatically check if such a C method is indeed leaf. Note that `rb_hash_has_key` is one of the functions that do need a stack frame because it may call `rb_funcall`.

## Benchmark
```yml
# bench.yml
prelude: |
  def kernel_class
    self.class
  end
  10.times { kernel_class }
benchmark: kernel_class
loop_count: 50000000
```

```
$ benchmark-driver -v --rbenv 'before::yjit-before;after::yjit' bench.yml
before: ruby 3.1.0dev (2021-05-27T17:59:41Z main 5fa1c7f221) [x86_64-linux]
YJIT is enabled
after: ruby 3.1.0dev (2021-05-31T23:50:27Z inline-cfunc d6d6a9587a) [x86_64-linux]
YJIT is enabled
Calculating -------------------------------------
                         before       after
        kernel_class    33.942M     44.527M i/s -     50.000M times in 1.473080s 1.122914s

Comparison:
                     kernel_class
               after:  44527016.4 i/s
              before:  33942479.2 i/s - 1.31x  slower
```