### PR TITLE
Disable YJIT while running MJIT tests

### DIFF
--- a/.github/workflows/mjit.yml
+++ b/.github/workflows/mjit.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       TESTOPTS: '-q --tty=no'
-      RUN_OPTS: '--disable-gems ${{ matrix.jit_opts }} --jit-debug=-ggdb3'
+      RUN_OPTS: '--disable-gems ${{ matrix.jit_opts }} --jit-debug=-ggdb3 --disable-yjit'
       GITPULLOPTIONS: --no-tags origin ${{github.ref}}
     steps:
       - run: mkdir build


### PR DESCRIPTION
Two JITs running at once may result in strange interactions.  Lets
disable YJIT while running the MJIT tests.