### PR TITLE
Fix check for leaf invokebuiltin

### DIFF
--- a/yjit_codegen.c
+++ b/yjit_codegen.c
@@ -2450,8 +2450,7 @@ rb_leaf_invokebuiltin_iseq_p(const rb_iseq_t *iseq)
     unsigned int invokebuiltin_len = insn_len(BIN(opt_invokebuiltin_delegate_leave));
     unsigned int leave_len = insn_len(BIN(leave));
 
-    return iseq->body->iseq_size == (
-        (invokebuiltin_len + leave_len) &&
+    return (iseq->body->iseq_size == (invokebuiltin_len + leave_len) &&
         rb_vm_insn_addr2opcode((void *)iseq->body->iseq_encoded[0]) == BIN(opt_invokebuiltin_delegate_leave) &&
         rb_vm_insn_addr2opcode((void *)iseq->body->iseq_encoded[invokebuiltin_len]) == BIN(leave) &&
         iseq->body->builtin_inline_p
@@ -2536,6 +2535,8 @@ gen_send_iseq(jitstate_t *jit, ctx_t *ctx, const struct rb_callinfo *ci, const r
     const struct rb_builtin_function *leaf_builtin = rb_leaf_builtin_function(iseq);
 
     if (leaf_builtin && !block && leaf_builtin->argc + 1 <= NUM_C_ARG_REGS) {
+        ADD_COMMENT(cb, "inlined leaf builtin");
+
         // TODO: figure out if this is necessary
         // If the calls don't allocate, do they need up to date PC, SP?
         // Save YJIT registers


### PR DESCRIPTION
Some mismatched parentheses caused this to return false incorrectly 😅

Also adds a comment when inlining a leaf builtin.

Generated asm for `Object.class`:

Before:
```
== BLOCK 1/3: 13 BYTES, ISEQ RANGE [0,3) =======================================
  ; opt_getinlinecache
  55bde344a05d:  movabs rax, 0x7ffa5ff5e8b0
  55bde344a067:  mov    qword ptr [rdx], rax
== BLOCK 2/3: 0 BYTES, ISEQ RANGE [9,11) =======================================
== BLOCK 3/3: 188 BYTES, ISEQ RANGE [9,11) =====================================
  ; opt_send_without_block
  55bde344a06a:  mov    rax, qword ptr [rdx]
  ; guard known class
  55bde344a06d:  movabs rcx, 0x7ffa5ff5d730
  ; exit to interpreter
  55bde344a077:  cmp    qword ptr [rax + 8], rcx
  55bde344a07b:  jne    0x55bdeb44a049
  ; RUBY_VM_CHECK_INTS(ec)
  55bde344a081:  mov    eax, dword ptr [rsi + 0x2c]
  55bde344a084:  not    eax
  55bde344a086:  test   dword ptr [rsi + 0x28], eax
  55bde344a089:  jne    0x55bdeb44a06f
  ; stack overflow check
  55bde344a08f:  lea    rax, [rdx + 0x50]
  55bde344a093:  cmp    rdi, rax
  55bde344a096:  jle    0x55bdeb44a06f
  55bde344a09c:  lea    rax, [rdx]
  55bde344a09f:  mov    qword ptr [rdi + 8], rax
  55bde344a0a3:  movabs rax, 0x55bde3407688
  55bde344a0ad:  mov    qword ptr [rdi], rax
  55bde344a0b0:  lea    rax, [rdx + 0x20]
  55bde344a0b4:  movabs rcx, 0x7ffa5ff9ee88
  55bde344a0be:  mov    qword ptr [rax - 0x18], rcx
  55bde344a0c2:  mov    qword ptr [rax - 0x10], 0
  55bde344a0ca:  mov    qword ptr [rax - 8], 0x11110003
  55bde344a0d2:  sub    rdi, 0x40
  55bde344a0d6:  mov    qword ptr [rsi + 0x10], rdi
  55bde344a0da:  mov    qword ptr [rdi + 0x28], 0
  55bde344a0e2:  mov    qword ptr [rdi + 8], rax
  55bde344a0e6:  mov    qword ptr [rdi + 0x30], rax
  55bde344a0ea:  sub    rax, 8
  55bde344a0ee:  mov    qword ptr [rdi + 0x20], rax
  55bde344a0f2:  mov    rax, qword ptr [rdx]
  55bde344a0f5:  mov    qword ptr [rdi + 0x18], rax
  55bde344a0f9:  movabs rax, 0x7ffa5ff9a860
  55bde344a103:  mov    qword ptr [rdi + 0x10], rax
  55bde344a107:  movabs rax, 0x55bde33fccb0
  55bde344a111:  mov    qword ptr [rdi], rax
  55bde344a114:  movabs rax, 0x55bdeb44a092
  55bde344a11e:  mov    qword ptr [rdi + 0x38], rax
  55bde344a122:  mov    rdx, qword ptr [rdi + 8]
```


After:
```
== BLOCK 1/3: 13 BYTES, ISEQ RANGE [0,3) =======================================
  ; opt_getinlinecache
  556b2b3a105d:  movabs rax, 0x7f9bf24468b8
  556b2b3a1067:  mov    qword ptr [rdx], rax
== BLOCK 2/3: 0 BYTES, ISEQ RANGE [9,11) =======================================
== BLOCK 3/3: 116 BYTES, ISEQ RANGE [9,12) =====================================
  ; opt_send_without_block
  556b2b3a106a:  mov    rax, qword ptr [rdx]
  ; guard known class
  556b2b3a106d:  movabs rcx, 0x7f9bf2445738
  ; exit to interpreter
  556b2b3a1077:  cmp    qword ptr [rax + 8], rcx
  556b2b3a107b:  jne    0x556b333a1049
  ; RUBY_VM_CHECK_INTS(ec)
  556b2b3a1081:  mov    eax, dword ptr [rsi + 0x2c]
  556b2b3a1084:  not    eax
  556b2b3a1086:  test   dword ptr [rsi + 0x28], eax
  556b2b3a1089:  jne    0x556b333a106f
  ; inlined leaf builtin
  556b2b3a108f:  push   rdi
  556b2b3a1090:  push   rsi
  556b2b3a1091:  push   rdx
  556b2b3a1092:  push   rdx
  556b2b3a1093:  lea    rax, [rdx]
  556b2b3a1096:  mov    rdi, rsi
  556b2b3a1099:  mov    rsi, qword ptr [rax]
  556b2b3a109c:  call   0x556b291ba700
  556b2b3a10a1:  pop    rdx
  556b2b3a10a2:  pop    rdx
  556b2b3a10a3:  pop    rsi
  556b2b3a10a4:  pop    rdi
  556b2b3a10a5:  mov    qword ptr [rdx], rax
  ; leave
  ; exit to interpreter
  556b2b3a10a8:  mov    rax, qword ptr [rdi + 0x20]
  ; check for finish frame
  556b2b3a10ac:  test   byte ptr [rax], 0x20
  556b2b3a10af:  jne    0x556b333a1092
  ; RUBY_VM_CHECK_INTS(ec)
  556b2b3a10b5:  mov    eax, dword ptr [rsi + 0x2c]
  556b2b3a10b8:  not    eax
  556b2b3a10ba:  test   dword ptr [rsi + 0x28], eax
  556b2b3a10bd:  jne    0x556b333a1092
  556b2b3a10c3:  mov    rax, qword ptr [rdx]
  556b2b3a10c6:  add    rdi, 0x40
  556b2b3a10ca:  mov    qword ptr [rsi + 0x10], rdi
  556b2b3a10ce:  add    qword ptr [rdi + 8], 8
  556b2b3a10d3:  mov    rdx, qword ptr [rdi + 8]
  556b2b3a10d7:  mov    qword ptr [rdx - 8], rax
  556b2b3a10db:  jmp    qword ptr [rdi - 8]
```