### PR TITLE
Add duparray to YJIT codegen

### DIFF
--- a/yjit_codegen.c
+++ b/yjit_codegen.c
@@ -621,6 +621,28 @@ gen_newarray(jitstate_t* jit, ctx_t* ctx)
     return YJIT_KEEP_COMPILING;
 }
 
+// dup array
+static codegen_status_t
+gen_duparray(jitstate_t* jit, ctx_t* ctx)
+{
+    VALUE ary = jit_get_arg(jit, 0);
+
+    // Save the PC and SP because we are allocating
+    jit_save_pc(jit, REG0);
+    jit_save_sp(jit, ctx);
+
+    // call rb_ary_resurrect(VALUE ary);
+    yjit_save_regs(cb);
+    jit_mov_gc_ptr(jit, cb, C_ARG_REGS[0], ary);
+    call_ptr(cb, REG0, (void *)rb_ary_resurrect);
+    yjit_load_regs(cb);
+
+    x86opnd_t stack_ret = ctx_stack_push(ctx, TYPE_ARRAY);
+    mov(cb, stack_ret, RAX);
+
+    return YJIT_KEEP_COMPILING;
+}
+
 // new hash initialized from top N values
 static codegen_status_t
 gen_newhash(jitstate_t* jit, ctx_t* ctx)
@@ -3022,6 +3044,7 @@ yjit_init_codegen(void)
     yjit_reg_op(BIN(pop), gen_pop);
     yjit_reg_op(BIN(adjuststack), gen_adjuststack);
     yjit_reg_op(BIN(newarray), gen_newarray);
+    yjit_reg_op(BIN(duparray), gen_duparray);
     yjit_reg_op(BIN(newhash), gen_newhash);
     yjit_reg_op(BIN(concatstrings), gen_concatstrings);
     yjit_reg_op(BIN(putnil), gen_putnil);


### PR DESCRIPTION
`duparray` is used similarly to `newarray`, but when all the values are literals known at compile time.

For example

`[1,2]`

compiles into the bytecode

`duparray                               [1, 2]`

which this now compiles into

```
  ; duparray
  55817d1fcddd:  movabs rax, 0x55817cf0e6c0
  55817d1fcde7:  mov    qword ptr [rdi], rax
  55817d1fcdea:  push   rdi
  55817d1fcdeb:  push   rsi
  55817d1fcdec:  push   rdx
  55817d1fcded:  push   rdx
  55817d1fcdee:  movabs rdi, 0x7fa79f195bb0 (pointer to the array)
  55817d1fcdf8:  call   0x55817c56eaf0 (rb_ary_resurrect)
  55817d1fcdfd:  pop    rdx
  55817d1fcdfe:  pop    rdx
  55817d1fcdff:  pop    rsi
  55817d1fce00:  pop    rdi
  55817d1fce01:  mov    qword ptr [rdx], rax
```