### PR TITLE
Special-case !nil the way we already do with !true and !false.

### DIFF
--- a/yjit_codegen.c
+++ b/yjit_codegen.c
@@ -1975,7 +1975,7 @@ gen_opt_not(jitstate_t* jit, ctx_t* ctx)
     VALUE comptime_val = jit_peek_at_stack(jit, ctx, 0);
 
     // For the true/false case
-    if (comptime_val == Qtrue || comptime_val == Qfalse) {
+    if (comptime_val == Qtrue || comptime_val == Qfalse || comptime_val == Qnil) {
 
         // Get the operand from the stack
         x86opnd_t arg = ctx_stack_pop(ctx, 1);
@@ -1990,6 +1990,11 @@ gen_opt_not(jitstate_t* jit, ctx_t* ctx)
         // Qfalse => Qtrue
         mov(cb, REG0, imm_opnd(Qtrue));
         cmp(cb, arg, imm_opnd(Qfalse));
+        je_label(cb, DONE);
+
+        // Qnil => Qtrue
+        mov(cb, REG0, imm_opnd(Qtrue));
+        cmp(cb, arg, imm_opnd(Qnil));
         je_label(cb, DONE);
 
         // For any other values, we side-exit


### PR DESCRIPTION
With the yaml-load benchmark I'm working on for yjit-bench (https://github.com/Shopify/yjit-bench/pull/22) this reduces side-exits from opt_not to zero, where they were previously around 12% of side exits.

This runs correctly with "make test-all" for me locally.