### PR TITLE
Allow to enable `--yjit-stats` via a env variable

### DIFF
--- a/yjit_iface.c
+++ b/yjit_iface.c
@@ -1035,6 +1035,8 @@ rb_yjit_init(struct rb_yjit_options *options)
     rb_yjit_opts = *options;
     rb_yjit_opts.yjit_enabled = true;
 
+    rb_yjit_opts.gen_stats |= !!getenv("YJIT_STATS");
+
     // Normalize command-line options to default values
     if (rb_yjit_opts.exec_mem_size < 1) {
         rb_yjit_opts.exec_mem_size = 256;


### PR DESCRIPTION
### Context

I'd like to always print YJIT stats on our nightly CI, however it's a complex system and the vast majority of the code is shared with our regular ruby-head CI. 

So it's quite tricky to set `RUBYOPT="--yjit-stats"` only for YJIT builds, and even then it interfers with some scripts ran with regular ruby, which then abort complaining about that unknown option.

### Solution

This whole ordeal would be tremendously simpler if I could enable printing stats through an environment variable that would noop on regular ruby. This PR uses `YJIT_STATS=1`, but it could be anything.

 