### PR TITLE
Add opt_invokebuiltin_delegate (and opt_invokebuiltin_delegate_leave)

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -1040,6 +1040,36 @@ assert_equal 'foo123', %q{
   make_str("foo", 123)
 }
 
+# test invokebuiltin_delegate as used inside Dir.open
+assert_equal '.', %q{
+  def foo(path)
+    Dir.open(path).path
+  end
+
+  foo(".")
+  foo(".")
+}
+
+# test invokebuiltin_delegate_leave in method called from jit
+assert_normal_exit %q{
+  def foo(obj)
+    obj.clone
+  end
+
+  foo(Object.new)
+  foo(Object.new)
+}
+
+# test invokebuiltin_delegate_leave in method called from cfunc
+assert_normal_exit %q{
+  def foo(obj)
+    [obj].map(&:clone)
+  end
+
+  foo(Object.new)
+  foo(Object.new)
+}
+
 # getlocal with 2 levels
 assert_equal '7', %q{
   def foo(foo, bar)

--- a/yjit_codegen.c
+++ b/yjit_codegen.c
@@ -3288,6 +3288,7 @@ yjit_init_codegen(void)
     yjit_reg_op(BIN(opt_not), gen_opt_not);
     yjit_reg_op(BIN(opt_getinlinecache), gen_opt_getinlinecache);
     yjit_reg_op(BIN(opt_invokebuiltin_delegate), gen_opt_invokebuiltin_delegate);
+    yjit_reg_op(BIN(opt_invokebuiltin_delegate_leave), gen_opt_invokebuiltin_delegate);
     yjit_reg_op(BIN(branchif), gen_branchif);
     yjit_reg_op(BIN(branchunless), gen_branchunless);
     yjit_reg_op(BIN(branchnil), gen_branchnil);

--- a/yjit_codegen.c
+++ b/yjit_codegen.c
@@ -3166,6 +3166,56 @@ gen_getblockparamproxy(jitstate_t *jit, ctx_t *ctx)
     return YJIT_KEEP_COMPILING;
 }
 
+// opt_invokebuiltin_delegate calls a builtin function, like
+// invokebuiltin does, but instead of taking arguments from the top of the
+// stack uses the argument locals (and self) from the current method.
+static codegen_status_t
+gen_opt_invokebuiltin_delegate(jitstate_t *jit, ctx_t *ctx)
+{
+    const struct rb_builtin_function *bf = (struct rb_builtin_function *)jit_get_arg(jit, 0);
+    int32_t start_index = (int32_t)jit_get_arg(jit, 1);
+
+    if (bf->argc + 2 >= NUM_C_ARG_REGS) {
+        return YJIT_CANT_COMPILE;
+    }
+
+    // If the calls don't allocate, do they need up to date PC, SP?
+    jit_save_pc(jit, REG0);
+    jit_save_sp(jit, ctx);
+
+    // Save YJIT registers
+    yjit_save_regs(cb);
+
+    if (bf->argc > 0) {
+        // Load environment pointer EP from CFP
+        mov(cb, REG0, member_opnd(REG_CFP, rb_control_frame_t, ep));
+    }
+
+    // Save self from CFP
+    mov(cb, REG1, member_opnd(REG_CFP, rb_control_frame_t, self));
+
+    // Call the builtin func (ec, recv, arg1, arg2, ...)
+    mov(cb, C_ARG_REGS[0], REG_EC); // clobbers REG_CFP
+    mov(cb, C_ARG_REGS[1], REG1); // self, clobbers REG_EC
+
+    // Copy arguments from locals
+    for (int32_t i = 0; i < bf->argc; i++) {
+        const int32_t offs = -jit->iseq->body->local_table_size - VM_ENV_DATA_SIZE + 1 + start_index + i;
+        x86opnd_t local_opnd = mem_opnd(64, REG0, offs * SIZEOF_VALUE);
+        x86opnd_t c_arg_reg = C_ARG_REGS[i + 2];
+        mov(cb, c_arg_reg, local_opnd);
+    }
+    call_ptr(cb, REG0, (void *)bf->func_ptr);
+
+    // Load YJIT registers
+    yjit_load_regs(cb);
+
+    // Push the return value
+    x86opnd_t stack_ret = ctx_stack_push(ctx, TYPE_UNKNOWN);
+    mov(cb, stack_ret, RAX);
+
+    return YJIT_KEEP_COMPILING;
+}
 
 static void
 yjit_reg_op(int opcode, codegen_fn gen_fn)
@@ -3237,6 +3287,7 @@ yjit_init_codegen(void)
     yjit_reg_op(BIN(opt_str_uminus), gen_opt_str_uminus);
     yjit_reg_op(BIN(opt_not), gen_opt_not);
     yjit_reg_op(BIN(opt_getinlinecache), gen_opt_getinlinecache);
+    yjit_reg_op(BIN(opt_invokebuiltin_delegate), gen_opt_invokebuiltin_delegate);
     yjit_reg_op(BIN(branchif), gen_branchif);
     yjit_reg_op(BIN(branchunless), gen_branchunless);
     yjit_reg_op(BIN(branchnil), gen_branchnil);


### PR DESCRIPTION
This adds opt_invokebuiltin_delegate, which we previously supported in cases where it could be trivially inlined. This adds it as a normal op for cases where it couldn't be inlined (not marked as 'inline', does more than just call, not called from yjit, etc). 

This also adds `gen_opt_invokebuiltin_delegate_leave` as an alias of `gen_opt_invokebuiltin_delegate` for YJIT. `gen_opt_invokebuiltin_delegate_leave` always still includes the following `leave` instruction so it is safe to consider them equivalent (the interpreter does this when needing to use trace instructions).

```
$ ./ruby --disable-gems --yjit-call-threshold=1 -e 'Object.new.clone; puts YJIT.disasm(Object.instance_method(:clone))'
== disasm: #<ISeq:clone@<internal:kernel>:47 (47,2)-(49,5)> (catch: FALSE)
local table (size: 2, argc: 0 [opts: 0, rest: -1, post: 0, block: -1, kw: 1@0, kwrest: -1])
[ 2] freeze@0   [ 1] ?@1
0000 opt_invokebuiltin_delegate_leave       <builtin!rb_obj_clone2/1>, 0(  48)[LiCa]
0003 leave                                                            (  49)[Re]

== BLOCK 1/1: 101 BYTES, ISEQ RANGE [0,4) ======================================
  ; opt_invokebuiltin_delegate_leave
  5644c642e9dd:  movabs rax, 0x5644c631c9f8
  5644c642e9e7:  mov    qword ptr [rdi], rax
  5644c642e9ea:  push   rdi
  5644c642e9eb:  push   rsi
  5644c642e9ec:  push   rdx
  5644c642e9ed:  push   rdx
  5644c642e9ee:  mov    rax, qword ptr [rdi + 0x20]
  5644c642e9f2:  mov    rcx, qword ptr [rdi + 0x18]
  5644c642e9f6:  mov    rdi, rsi
  5644c642e9f9:  mov    rsi, rcx
  5644c642e9fc:  mov    rdx, qword ptr [rax - 0x20]
  5644c642ea00:  call   0x5644c4649870
  5644c642ea05:  pop    rdx
  5644c642ea06:  pop    rdx
  5644c642ea07:  pop    rsi
  5644c642ea08:  pop    rdi
  5644c642ea09:  mov    qword ptr [rdx], rax
  ; leave
  5644c642ea0c:  mov    rax, qword ptr [rdi + 0x20]
  ; check for finish frame
  5644c642ea10:  test   byte ptr [rax], 0x20
  5644c642ea13:  jne    0x5644ce42e0b3
  ; RUBY_VM_CHECK_INTS(ec)
  5644c642ea19:  mov    eax, dword ptr [rsi + 0x2c]
  5644c642ea1c:  not    eax
  5644c642ea1e:  test   dword ptr [rsi + 0x28], eax
  5644c642ea21:  jne    0x5644ce42e0b3
  5644c642ea27:  mov    rax, qword ptr [rdx]
  5644c642ea2a:  add    rdi, 0x40
  5644c642ea2e:  mov    qword ptr [rsi + 0x10], rdi
  5644c642ea32:  add    qword ptr [rdi + 8], 8
  5644c642ea37:  mov    rdx, qword ptr [rdi + 8]
  5644c642ea3b:  mov    qword ptr [rdx - 8], rax
  5644c642ea3f:  jmp    qword ptr [rdi - 8]
```

This is a bit hard to test, because we can't make arbitrary builtins (they're created as part of the build process), so the test I added calls some existing ones.