### PR TITLE
Allow yjit.rb to work with frozen strings

### DIFF
--- a/yjit.rb
+++ b/yjit.rb
@@ -6,7 +6,7 @@ module YJIT
       blocks = YJIT.blocks_for(iseq)
       return if blocks.empty?
 
-      str = ""
+      str = String.new
       str << iseq.disasm
       str << "\n"
 


### PR DESCRIPTION
This will be necessary if https://github.com/ruby/ruby/pull/4573 lands (and otherwise shouldn't hurt anything)