### PR TITLE
Warn rather than raise when --yjit-stats is ignored

### DIFF
--- a/yjit_iface.c
+++ b/yjit_iface.c
@@ -1040,7 +1040,7 @@ rb_yjit_init(struct rb_yjit_options *options)
 
 #if !RUBY_DEBUG
     if(rb_yjit_opts.gen_stats) {
-        rb_raise(rb_eRuntimeError, "--yjit-stats requires that Ruby is compiled with CPPFLAGS='-DRUBY_DEBUG=1'");
+        rb_warning("--yjit-stats requires that Ruby is compiled with CPPFLAGS='-DRUBY_DEBUG=1'");
     }
 #endif
 


### PR DESCRIPTION
Followup: https://github.com/Shopify/yjit/pull/84

The main goal was to be able to set `YJIT_STATS=1` without any adverse effect. I totally overlooked that YJIT would raise when it can't enable it.

I don't think raising is worth it, a warning is enough.