### PR TITLE
Simplify known class check for singleton classes

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -1153,3 +1153,34 @@ assert_equal '7', %q{
   foo(5,2)
   foo(5,2)
 }
+
+# Call to object with singleton
+assert_equal '123', %q{
+  obj = Object.new
+  def obj.foo
+    123
+  end
+
+  def foo(obj)
+    obj.foo()
+  end
+
+  foo(obj)
+  foo(obj)
+}
+
+# Call to singleton class
+assert_equal '123', %q{
+  class Foo
+    def self.foo
+      123
+    end
+  end
+
+  def foo(obj)
+    obj.foo()
+  end
+
+  foo(Foo)
+  foo(Foo)
+}


### PR DESCRIPTION
Singleton classes should only ever be attached to one object. This means that checking for the object should be the same as checking for the class. This should be slightly faster by avoiding one memory access as well as allowing us to skip checking if the receiver is a heap object.

This will be most common for calling class methods.

For example, when calling `Thread.current`, previously we would generate the check

```
  ; opt_send_without_block
  56502dca79aa:  mov    rax, qword ptr [rdx]
  ; guard known class
  56502dca79ad:  movabs rcx, 0x7f502eb0d238 ; This is Thread.singleton_class
  56502dca79b7:  cmp    qword ptr [rax + 8], rcx
  56502dca79bb:  jne    0x565035ca4e90
```

but now we generate

```
== BLOCK 3/4: 180 BYTES, ISEQ RANGE [9,11) =====================================
  ; opt_send_without_block
  55dd72f3f92a:  mov    rax, qword ptr [rdx]
  ; guard known object with singleton class
  55dd72f3f92d:  movabs rcx, 0x7f817670d268 ; This is `Thread`
  55dd72f3f937:  cmp    rax, rcx
  55dd72f3f93a:  jne    0x55dd7af3ce90
```