### PR TITLE
Disable invokesuper codegen for now. Add test

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -1204,3 +1204,23 @@ assert_equal '123', %q{
   foo(Foo)
   foo(Foo)
 }
+
+# invokesuper edge case
+assert_equal '[:A, [:A, :B]]', %q{
+  class B
+    def foo = :B
+  end
+
+  class A < B
+    def foo = [:A, super()]
+  end
+
+  A.new.foo
+  A.new.foo # compile A#foo
+
+  class C < A
+    define_method(:bar, A.instance_method(:foo))
+  end
+
+  C.new.bar
+}

--- a/yjit_codegen.c
+++ b/yjit_codegen.c
@@ -2972,6 +2972,7 @@ gen_send(jitstate_t *jit, ctx_t *ctx)
     return gen_send_general(jit, ctx, cd, block);
 }
 
+RBIMPL_ATTR_MAYBE_UNUSED() // not in use as it has problems in some situations.
 static codegen_status_t
 gen_invokesuper(jitstate_t *jit, ctx_t *ctx)
 {
@@ -3353,6 +3354,5 @@ yjit_init_codegen(void)
     yjit_reg_op(BIN(getblockparamproxy), gen_getblockparamproxy);
     yjit_reg_op(BIN(opt_send_without_block), gen_opt_send_without_block);
     yjit_reg_op(BIN(send), gen_send);
-    yjit_reg_op(BIN(invokesuper), gen_invokesuper);
     yjit_reg_op(BIN(leave), gen_leave);
 }


### PR DESCRIPTION
The added test fails with SystemStackError with --yjit-call-threshold=1.

---

I haven't had time to dig into the details for this, but in general I think `invokesuper` doesn't fit into YJIT's current invalidation scheme nicely. The way it uses `assume_method_lookup_stable()` works, but is stepping into territory that the function wasn't designed to do. I wouldn't be surprised if there are other problems.