### PR TITLE
Fix incorrect recursion in invokesuper

### DIFF
--- a/yjit_codegen.c
+++ b/yjit_codegen.c
@@ -3050,7 +3050,7 @@ gen_invokesuper(jitstate_t *jit, ctx_t *ctx)
     const rb_callable_method_entry_t *ancestor_cme;
     while (ancestor) {
         ancestor_cme = rb_callable_method_entry(ancestor, mid);
-        if (ancestor_cme && ancestor_cme->def == cme->def) {
+        if (ancestor_cme && ancestor_cme->def == me->def) {
             return YJIT_CANT_COMPILE;
         }
         ancestor = RCLASS_SUPER(ancestor);


### PR DESCRIPTION
A potential fix for #95

This adjusts the ancestor check to check not for just re-including the same module but any case where an ancestor has the same method. This fixes Alan's test case (and the existing Ruby tests for similar behaviours), but I'm not 100% sure there isn't still some edge case it won't catch (requires more thought).