### PR TITLE
Add test of YJIT compilation

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -8680,6 +8680,18 @@ mjit_build_dir.$(OBJEXT): {$(VPATH)}internal/compiler_since.h
 mjit_build_dir.$(OBJEXT): {$(VPATH)}internal/config.h
 mjit_build_dir.$(OBJEXT): {$(VPATH)}ruby-runner.c
 mjit_build_dir.$(OBJEXT): {$(VPATH)}ruby-runner.h
+mjit_build_dir.so-ruby-runner.$(OBJEXT): {$(VPATH)}config.h
+mjit_build_dir.so-ruby-runner.$(OBJEXT): {$(VPATH)}internal/compiler_is.h
+mjit_build_dir.so-ruby-runner.$(OBJEXT): {$(VPATH)}internal/compiler_is/apple.h
+mjit_build_dir.so-ruby-runner.$(OBJEXT): {$(VPATH)}internal/compiler_is/clang.h
+mjit_build_dir.so-ruby-runner.$(OBJEXT): {$(VPATH)}internal/compiler_is/gcc.h
+mjit_build_dir.so-ruby-runner.$(OBJEXT): {$(VPATH)}internal/compiler_is/intel.h
+mjit_build_dir.so-ruby-runner.$(OBJEXT): {$(VPATH)}internal/compiler_is/msvc.h
+mjit_build_dir.so-ruby-runner.$(OBJEXT): {$(VPATH)}internal/compiler_is/sunpro.h
+mjit_build_dir.so-ruby-runner.$(OBJEXT): {$(VPATH)}internal/compiler_since.h
+mjit_build_dir.so-ruby-runner.$(OBJEXT): {$(VPATH)}internal/config.h
+mjit_build_dir.so-ruby-runner.$(OBJEXT): {$(VPATH)}ruby-runner.c
+mjit_build_dir.so-ruby-runner.$(OBJEXT): {$(VPATH)}ruby-runner.h
 mjit_compile.$(OBJEXT): $(CCAN_DIR)/check_type/check_type.h
 mjit_compile.$(OBJEXT): $(CCAN_DIR)/container_of/container_of.h
 mjit_compile.$(OBJEXT): $(CCAN_DIR)/list/list.h
@@ -17202,6 +17214,7 @@ yjit_iface.$(OBJEXT): {$(VPATH)}vm_debug.h
 yjit_iface.$(OBJEXT): {$(VPATH)}vm_opts.h
 yjit_iface.$(OBJEXT): {$(VPATH)}vm_sync.h
 yjit_iface.$(OBJEXT): {$(VPATH)}yjit.h
+yjit_iface.$(OBJEXT): {$(VPATH)}yjit.rb
 yjit_iface.$(OBJEXT): {$(VPATH)}yjit.rbinc
 yjit_iface.$(OBJEXT): {$(VPATH)}yjit_asm.h
 yjit_iface.$(OBJEXT): {$(VPATH)}yjit_codegen.h

--- a/test/ruby/test_yjit.rb
+++ b/test/ruby/test_yjit.rb
@@ -9,54 +9,54 @@ return unless YJIT.enabled?
 # insipired by the MJIT tests in test/ruby/test_jit.rb
 class TestYJIT < Test::Unit::TestCase
   def test_compile_putnil
-    assert_compiles('nil', insns: %i[putnil], stdout: 'nil')
+    assert_compiles('nil', insns: %i[putnil], result: nil)
   end
 
   def test_compile_putobject
-    assert_compiles('true', insns: %i[putobject], stdout: 'true')
-    assert_compiles('123', insns: %i[putobject], stdout: '123')
-    assert_compiles(':foo', insns: %i[putobject], stdout: ':foo')
+    assert_compiles('true', insns: %i[putobject], result: true)
+    assert_compiles('123', insns: %i[putobject], result: 123)
+    assert_compiles(':foo', insns: %i[putobject], result: :foo)
   end
 
   def test_compile_opt_not
-    assert_compiles('!false', insns: %i[opt_not], stdout: 'true')
-    assert_compiles('!nil', insns: %i[opt_not], stdout: 'true')
-    assert_compiles('!true', insns: %i[opt_not], stdout: 'false')
-    assert_compiles('![]', insns: %i[opt_not], stdout: 'false')
+    assert_compiles('!false', insns: %i[opt_not], result: true)
+    assert_compiles('!nil', insns: %i[opt_not], result: true)
+    assert_compiles('!true', insns: %i[opt_not], result: false)
+    assert_compiles('![]', insns: %i[opt_not], result: false)
   end
 
   def test_compile_opt_newarray
-    assert_compiles('[]', insns: %i[newarray], stdout: '[]')
-    assert_compiles('[1+1]', insns: %i[newarray opt_plus], stdout: '[2]')
-    assert_compiles('[1,1+1,3,4,5,6]', insns: %i[newarray opt_plus], stdout: '[1, 2, 3, 4, 5, 6]')
+    assert_compiles('[]', insns: %i[newarray], result: [])
+    assert_compiles('[1+1]', insns: %i[newarray opt_plus], result: [2])
+    assert_compiles('[1,1+1,3,4,5,6]', insns: %i[newarray opt_plus], result: [1, 2, 3, 4, 5, 6])
   end
 
   def test_compile_opt_duparray
-    assert_compiles('[1]', insns: %i[duparray], stdout: '[1]')
-    assert_compiles('[1, 2, 3]', insns: %i[duparray], stdout: '[1, 2, 3]')
+    assert_compiles('[1]', insns: %i[duparray], result: [1])
+    assert_compiles('[1, 2, 3]', insns: %i[duparray], result: [1, 2, 3])
   end
 
   def test_compile_opt_nil_p
-    assert_compiles('nil.nil?', insns: %i[opt_nil_p], stdout: 'true')
-    assert_compiles('false.nil?', insns: %i[opt_nil_p], stdout: 'false')
-    assert_compiles('true.nil?', insns: %i[opt_nil_p], stdout: 'false')
-    assert_compiles('(-"").nil?', insns: %i[opt_nil_p], stdout: 'false')
-    assert_compiles('123.nil?', insns: %i[opt_nil_p], stdout: 'false')
+    assert_compiles('nil.nil?', insns: %i[opt_nil_p], result: true)
+    assert_compiles('false.nil?', insns: %i[opt_nil_p], result: false)
+    assert_compiles('true.nil?', insns: %i[opt_nil_p], result: false)
+    assert_compiles('(-"").nil?', insns: %i[opt_nil_p], result: false)
+    assert_compiles('123.nil?', insns: %i[opt_nil_p], result: false)
   end
 
   def test_compile_eq_fixnum
-    assert_compiles('123 == 123', insns: %i[opt_eq], stdout: 'true')
-    assert_compiles('123 == 456', insns: %i[opt_eq], stdout: 'false')
+    assert_compiles('123 == 123', insns: %i[opt_eq], result: true)
+    assert_compiles('123 == 456', insns: %i[opt_eq], result: false)
   end
 
   def test_compile_eq_string
-    assert_compiles('-"" == -""', insns: %i[opt_eq], stdout: 'true')
-    assert_compiles('-"foo" == -"foo"', insns: %i[opt_eq], stdout: 'true')
-    assert_compiles('-"foo" == -"bar"', insns: %i[opt_eq], stdout: 'false')
+    assert_compiles('-"" == -""', insns: %i[opt_eq], result: true)
+    assert_compiles('-"foo" == -"foo"', insns: %i[opt_eq], result: true)
+    assert_compiles('-"foo" == -"bar"', insns: %i[opt_eq], result: false)
   end
 
   def test_getlocal_with_level
-    assert_compiles(<<~RUBY, insns: %i[getlocal opt_plus], stdout: '[[7]]', exits: {leave: 2})
+    assert_compiles(<<~RUBY, insns: %i[getlocal opt_plus], result: [[7]], exits: {leave: 2})
       def foo(foo, bar)
         [1].map do |x|
           [1].map do |y|
@@ -70,7 +70,7 @@ class TestYJIT < Test::Unit::TestCase
   end
 
   def test_string_then_nil
-    assert_compiles(<<~RUBY, insns: %i[opt_nil_p], stdout: 'true')
+    assert_compiles(<<~RUBY, insns: %i[opt_nil_p], result: true)
       def foo(val)
         val.nil?
       end
@@ -81,7 +81,7 @@ class TestYJIT < Test::Unit::TestCase
   end
 
   def test_nil_then_string
-    assert_compiles(<<~RUBY, insns: %i[opt_nil_p], stdout: 'false')
+    assert_compiles(<<~RUBY, insns: %i[opt_nil_p], result: false)
       def foo(val)
         val.nil?
       end
@@ -92,7 +92,7 @@ class TestYJIT < Test::Unit::TestCase
   end
 
   def test_opt_length_in_method
-    assert_compiles(<<~RUBY, insns: %i[opt_length], stdout: '5')
+    assert_compiles(<<~RUBY, insns: %i[opt_length], result: 5)
       def foo(str)
         str.length
       end
@@ -103,7 +103,7 @@ class TestYJIT < Test::Unit::TestCase
   end
 
   def test_compile_opt_getinlinecache
-    assert_compiles(<<~RUBY, insns: %i[opt_getinlinecache], stdout: '123', min_calls: 2)
+    assert_compiles(<<~RUBY, insns: %i[opt_getinlinecache], result: 123, min_calls: 2)
       def get_foo
         FOO
       end
@@ -116,7 +116,7 @@ class TestYJIT < Test::Unit::TestCase
   end
 
   def test_string_interpolation
-    assert_compiles(<<~'RUBY', insns: %i[checktype concatstrings], stdout: '"foobar"', min_calls: 2)
+    assert_compiles(<<~'RUBY', insns: %i[checktype concatstrings], result: "foobar", min_calls: 2)
       def make_str(foo, bar)
         "#{foo}#{bar}"
       end
@@ -127,7 +127,7 @@ class TestYJIT < Test::Unit::TestCase
   end
 
   def test_fib_recursion
-    assert_compiles(<<~'RUBY', insns: %i[opt_le opt_minus opt_plus opt_send_without_block], stdout: '34')
+    assert_compiles(<<~'RUBY', insns: %i[opt_le opt_minus opt_plus opt_send_without_block], result: 34)
       def fib(n)
         return n if n <= 1
         fib(n-1) + fib(n-2)
@@ -141,13 +141,14 @@ class TestYJIT < Test::Unit::TestCase
     assert_compiles(script)
   end
 
-  def assert_compiles(test_script, insns: [], min_calls: 1, stdout: nil, exits: {})
+  ANY = Object.new
+  def assert_compiles(test_script, insns: [], min_calls: 1, stdout: nil, exits: {}, result: ANY)
     reset_stats = <<~RUBY
       YJIT.runtime_stats
       YJIT.reset_stats!
     RUBY
 
-    print_stats = <<~RUBY
+    write_results = <<~RUBY
       stats = YJIT.runtime_stats
 
       def collect_blocks(blocks)
@@ -170,6 +171,7 @@ class TestYJIT < Test::Unit::TestCase
 
       iseq = RubyVM::InstructionSequence.of(_test_proc)
       IO.open(3).write Marshal.dump({
+        result: result,
         stats: stats,
         iseqs: collect_iseqs(iseq),
         disasm: iseq.disasm
@@ -181,8 +183,8 @@ class TestYJIT < Test::Unit::TestCase
         #{test_script}
       }
       #{reset_stats}
-      p _test_proc.call
-      #{print_stats}
+      result = _test_proc.call
+      #{write_results}
     RUBY
 
     status, out, err, stats = eval_with_jit(script, min_calls: min_calls)
@@ -190,6 +192,10 @@ class TestYJIT < Test::Unit::TestCase
     assert status.success?, "exited with status #{status.to_i}, stderr:\n#{err}"
 
     assert_equal stdout.chomp, out.chomp if stdout
+
+    unless ANY.equal?(result)
+      assert_equal result, stats[:result]
+    end
 
     runtime_stats = stats[:stats]
     iseqs = stats[:iseqs]

--- a/test/ruby/test_yjit.rb
+++ b/test/ruby/test_yjit.rb
@@ -137,6 +137,10 @@ class TestYJIT < Test::Unit::TestCase
     RUBY
   end
 
+  def assert_no_exits(script)
+    assert_compiles(script)
+  end
+
   def assert_compiles(test_script, insns: [], min_calls: 1, stdout: nil, exits: {})
     reset_stats = <<~RUBY
       YJIT.runtime_stats

--- a/test/ruby/test_yjit.rb
+++ b/test/ruby/test_yjit.rb
@@ -1,0 +1,228 @@
+# frozen_string_literal: true
+require 'test/unit'
+require 'envutil'
+require 'tmpdir'
+
+return unless YJIT.enabled?
+
+# Tests for YJIT with assertions on compilation and side exits
+# insipired by the MJIT tests in test/ruby/test_jit.rb
+class TestYJIT < Test::Unit::TestCase
+  def test_compile_putnil
+    assert_compiles('nil', insns: %i[putnil], stdout: 'nil')
+  end
+
+  def test_compile_putobject
+    assert_compiles('true', insns: %i[putobject], stdout: 'true')
+    assert_compiles('123', insns: %i[putobject], stdout: '123')
+    assert_compiles(':foo', insns: %i[putobject], stdout: ':foo')
+  end
+
+  def test_compile_opt_not
+    assert_compiles('!false', insns: %i[opt_not], stdout: 'true')
+    assert_compiles('!nil', insns: %i[opt_not], stdout: 'true')
+    assert_compiles('!true', insns: %i[opt_not], stdout: 'false')
+    assert_compiles('![]', insns: %i[opt_not], stdout: 'false')
+  end
+
+  def test_compile_opt_newarray
+    assert_compiles('[]', insns: %i[newarray], stdout: '[]')
+    assert_compiles('[1+1]', insns: %i[newarray opt_plus], stdout: '[2]')
+    assert_compiles('[1,1+1,3,4,5,6]', insns: %i[newarray opt_plus], stdout: '[1, 2, 3, 4, 5, 6]')
+  end
+
+  def test_compile_opt_duparray
+    assert_compiles('[1]', insns: %i[duparray], stdout: '[1]')
+    assert_compiles('[1, 2, 3]', insns: %i[duparray], stdout: '[1, 2, 3]')
+  end
+
+  def test_compile_opt_nil_p
+    assert_compiles('nil.nil?', insns: %i[opt_nil_p], stdout: 'true')
+    assert_compiles('false.nil?', insns: %i[opt_nil_p], stdout: 'false')
+    assert_compiles('true.nil?', insns: %i[opt_nil_p], stdout: 'false')
+    assert_compiles('(-"").nil?', insns: %i[opt_nil_p], stdout: 'false')
+    assert_compiles('123.nil?', insns: %i[opt_nil_p], stdout: 'false')
+  end
+
+  def test_compile_eq_fixnum
+    assert_compiles('123 == 123', insns: %i[opt_eq], stdout: 'true')
+    assert_compiles('123 == 456', insns: %i[opt_eq], stdout: 'false')
+  end
+
+  def test_compile_eq_string
+    assert_compiles('-"" == -""', insns: %i[opt_eq], stdout: 'true')
+    assert_compiles('-"foo" == -"foo"', insns: %i[opt_eq], stdout: 'true')
+    assert_compiles('-"foo" == -"bar"', insns: %i[opt_eq], stdout: 'false')
+  end
+
+  def test_string_then_nil
+    assert_compiles(<<~RUBY, insns: %i[opt_nil_p], stdout: 'true')
+      def foo(val)
+        val.nil?
+      end
+
+      foo("foo")
+      foo(nil)
+    RUBY
+  end
+
+  def test_nil_then_string
+    assert_compiles(<<~RUBY, insns: %i[opt_nil_p], stdout: 'false')
+      def foo(val)
+        val.nil?
+      end
+
+      foo(nil)
+      foo("foo")
+    RUBY
+  end
+
+  def test_opt_length_in_method
+    assert_compiles(<<~RUBY, insns: %i[opt_length], stdout: '5')
+      def foo(str)
+        str.length
+      end
+
+      foo("hello, ")
+      foo("world")
+    RUBY
+  end
+
+  def test_compile_opt_getinlinecache
+    assert_compiles(<<~RUBY, insns: %i[opt_getinlinecache], stdout: '123', min_calls: 2)
+      def get_foo
+        FOO
+      end
+
+      FOO = 123
+
+      get_foo # warm inline cache
+      get_foo
+    RUBY
+  end
+
+  def test_string_interpolation
+    assert_compiles(<<~'RUBY', insns: %i[checktype concatstrings], stdout: '"foobar"', min_calls: 2)
+      def make_str(foo, bar)
+        "#{foo}#{bar}"
+      end
+
+      make_str("foo", "bar")
+      make_str("foo", "bar")
+    RUBY
+  end
+
+  def assert_compiles(test_script, insns: [], min_calls: 1, stdout: nil, exits: {})
+    reset_stats = <<~RUBY
+      YJIT.runtime_stats
+      YJIT.reset_stats!
+    RUBY
+
+    print_stats = <<~RUBY
+      stats = YJIT.runtime_stats
+
+      def collect_blocks(blocks)
+        blocks.sort_by(&:address).map { |b| [b.iseq_start_index, b.iseq_end_index] }
+      end
+
+      def collect_iseqs(iseq)
+        iseq_array = iseq.to_a
+        insns = iseq_array.last.grep(Array)
+        blocks = YJIT.blocks_for(iseq)
+        h = {
+          name: iseq_array[5],
+          insns: insns,
+          blocks: collect_blocks(blocks),
+        }
+        arr = [h]
+        iseq.each_child { |c| arr.concat collect_iseqs(c) }
+        arr
+      end
+
+      iseq = RubyVM::InstructionSequence.of(_test_proc)
+      IO.open(3).write Marshal.dump({
+        stats: stats,
+        iseqs: collect_iseqs(iseq),
+        disasm: iseq.disasm
+      })
+    RUBY
+
+    script = <<~RUBY
+      _test_proc = proc {
+        #{test_script}
+      }
+      #{reset_stats}
+      p _test_proc.call
+      #{print_stats}
+    RUBY
+
+    status, out, err, stats = eval_with_jit(script, min_calls: min_calls)
+
+    assert status.success?, "exited with status #{status.to_i}, stderr:\n#{err}"
+
+    assert_equal stdout.chomp, out.chomp if stdout
+
+    runtime_stats = stats[:stats]
+    iseqs = stats[:iseqs]
+    disasm = stats[:disasm]
+
+    if stats[:stats]
+      # Only available when RUBY_DEBUG enabled
+      recorded_exits = stats[:stats].select { |k, v| k.to_s.start_with?("exit_") }
+      recorded_exits = recorded_exits.reject { |k, v| v == 0 }
+      recorded_exits.transform_keys! { |k| k.to_s.gsub("exit_", "").to_sym }
+      if exits != :any && exits != recorded_exits
+        flunk "Expected #{exits.empty? ? "no" : exits.inspect} exits" \
+          ", but got\n#{recorded_exits.inspect}"
+      end
+    end
+
+    if stats[:stats]
+      # Only available when RUBY_DEBUG enabled
+      missed_insns = insns.dup
+      all_compiled_blocks = {}
+      iseqs.each do |iseq|
+        compiled_blocks = iseq[:blocks].map { |from, to| (from...to) }
+        all_compiled_blocks[iseq[:name]] = compiled_blocks
+        compiled_insns = iseq[:insns]
+        next_idx = 0
+        compiled_insns.map! do |insn|
+          # TODO: not sure this is accurate for determining insn size
+          idx = next_idx
+          next_idx += insn.length
+          [idx, *insn]
+        end
+
+        compiled_insns.each do |idx, op, *arguments|
+          next unless missed_insns.include?(op)
+          next unless compiled_blocks.any? { |block| block === idx }
+
+          # This instruction was compiled
+          missed_insns.delete(op)
+        end
+      end
+
+      unless missed_insns.empty?
+        flunk "Expected to compile instructions #{missed_insns.join(", ")} but didn't.\nCompiled ranges: #{all_compiled_blocks.inspect}\niseq:\n#{disasm}"
+      end
+    end
+  end
+
+  def eval_with_jit(script, min_calls: 1, timeout: 1000)
+    args = [
+      "--disable-gems",
+      "--yjit-call-threshold=#{min_calls}",
+      "--yjit-stats"
+    ]
+    args << "-e" << script
+    stats_r, stats_w = IO.pipe
+    out, err, status = EnvUtil.invoke_ruby(args,
+      '', true, true, timeout: timeout, ios: {3 => stats_w}
+    )
+    stats_w.close
+    stats = stats_r.read
+    stats = Marshal.load(stats) if !stats.empty?
+    stats_r.close
+    [status, out, err, stats]
+  end
+end

--- a/test/ruby/test_yjit.rb
+++ b/test/ruby/test_yjit.rb
@@ -112,6 +112,17 @@ class TestYJIT < Test::Unit::TestCase
     RUBY
   end
 
+  def test_recursion
+    assert_compiles(<<~'RUBY', insns: %i[opt_le opt_minus opt_plus], stdout: '34')
+      def fib(n)
+        return n if n <= 1
+        fib(n-1) + fib(n-2)
+      end
+
+      fib(9)
+    RUBY
+  end
+
   def assert_compiles(test_script, insns: [], min_calls: 1, stdout: nil, exits: {})
     reset_stats = <<~RUBY
       YJIT.runtime_stats

--- a/test/ruby/test_yjit.rb
+++ b/test/ruby/test_yjit.rb
@@ -55,6 +55,20 @@ class TestYJIT < Test::Unit::TestCase
     assert_compiles('-"foo" == -"bar"', insns: %i[opt_eq], stdout: 'false')
   end
 
+  def test_getlocal_with_level
+    assert_compiles(<<~RUBY, insns: %i[getlocal opt_plus], stdout: '[[7]]', exits: {leave: 2})
+      def foo(foo, bar)
+        [1].map do |x|
+          [1].map do |y|
+            foo + bar
+          end
+        end
+      end
+
+      foo(5, 2)
+    RUBY
+  end
+
   def test_string_then_nil
     assert_compiles(<<~RUBY, insns: %i[opt_nil_p], stdout: 'true')
       def foo(val)
@@ -112,8 +126,8 @@ class TestYJIT < Test::Unit::TestCase
     RUBY
   end
 
-  def test_recursion
-    assert_compiles(<<~'RUBY', insns: %i[opt_le opt_minus opt_plus], stdout: '34')
+  def test_fib_recursion
+    assert_compiles(<<~'RUBY', insns: %i[opt_le opt_minus opt_plus opt_send_without_block], stdout: '34')
       def fib(n)
         return n if n <= 1
         fib(n-1) + fib(n-2)

--- a/yjit.rb
+++ b/yjit.rb
@@ -134,6 +134,10 @@ module YJIT
     Primitive.reset_stats_bang
   end
 
+  def self.enabled?
+    Primitive.cexpr! 'rb_yjit_enabled_p() ? Qtrue : Qfalse'
+  end
+
   class << self
     private
 


### PR DESCRIPTION
Addresses (at least part of) #98

This takes a similar approach to an existing test for MJIT, which compiles small snippets and asserts that the instruction intended to be tested actually existed in the script given. This test goes a step further and asserts that YJIT ended up compiling at least one block for the specific instruction we're testing. This also optionally performs an assert on the expected number of side exits per-opcode.

To do this it invokes Ruby in a subprocess, so that we have full control over the runtime (🤞 no interrupts) and can reset our stats without worry. Runtime stats are sent back Marshal'd over a file descriptor.

I think this is maybe best illustrated by looking at some tests which would fail (which I legitimately ran into when writing a few samples 😅)

---

``` ruby
assert_compiles('"" == ""', insns: %i[opt_eq], stdout: 'true')
```

```
TestYJIT#test_compile_eq_string [/home/jhawthorn/src/yjit/test/ruby/test_yjit.rb:32]:
Expected to compile instructions opt_eq but didn't.
Compiled ranges: [0...0]
iseq:
== disasm: #<ISeq:<compiled>@<compiled>:1 (1,0)-(1,8)> (catch: FALSE)
0000 putstring                              ""                        (   1)[Li]
0002 putstring                              ""
0004 opt_eq                                 <calldata!mid:==, argc:1, ARGS_SIMPLE>
0006 leave
```

Fails because we weren't able to compile `putstring` and the `opt_eq` never ended up in any blocks. You can see the working version of this test included in this commit which uses `-""` (`opt_uminus`) instead.

---

``` ruby
assert_compiles('123.nil?', insns: %i[opt_nil_p], stdout: 'false')
```

```
TestYJIT#test_compile_opt_nil_p [/home/jhawthorn/src/yjit/test/ruby/test_yjit.rb:24]:
Expected no exits, but got
{:opt_nil_p=>1}
```

You can see the working version of this test included, which specifies that we're allowed to side exit once on this instruction (but that it still needs to be compiled)


---

**TODO**
- [x] ~Currently this puts the given script into a method. We probably want to evaluate at the top level and allow defining our own methods, but that makes finding the right iseqs (the mjit tests look for iseqs recursively) and matching them up with blocks a little more difficult.~ Fixed, now recursively checks iseqs in the provided script
- [x] ~I'm not certain the way I'm tracking iseq offsets is correct~ seems good
- [x] ~I'm not sure if side exits due to interrupts are a concern~ hasn't been a problem
- [x] ~When the scripts errors, the output is a bit messy due to being run with `--yjit-stats`. Maybe we want to separate recording stats from printing stats?~ Might as well do this in a separate PR
- [x] Need to skip this test if compiling without RUBY_DEBUG
- [x] Need to skip this test on unsupported platforms