### PR TITLE
Add a macro for tweaking default call threshold

### DIFF
--- a/yjit_iface.c
+++ b/yjit_iface.c
@@ -1098,7 +1098,7 @@ rb_yjit_init(struct rb_yjit_options *options)
         rb_yjit_opts.exec_mem_size = 256;
     }
     if (rb_yjit_opts.call_threshold < 1) {
-        rb_yjit_opts.call_threshold = 10;
+        rb_yjit_opts.call_threshold = YJIT_DEFAULT_CALL_THRESHOLD;
     }
     if (rb_yjit_opts.max_versions < 1) {
         rb_yjit_opts.max_versions = 4;

--- a/yjit_iface.h
+++ b/yjit_iface.h
@@ -11,6 +11,10 @@
 #include "vm_core.h"
 #include "yjit_core.h"
 
+#ifndef YJIT_DEFAULT_CALL_THRESHOLD
+# define YJIT_DEFAULT_CALL_THRESHOLD 10
+#endif
+
 #if RUBY_DEBUG
 
 #define YJIT_DECLARE_COUNTERS(...) struct rb_yjit_runtime_counters { \
@@ -112,4 +116,4 @@ const VALUE *rb_yjit_count_side_exit_op(const VALUE *exit_pc);
 void yjit_unlink_method_lookup_dependency(block_t *block);
 void yjit_block_assumptions_free(block_t *block);
 
-#endif // #ifndef YJIT_IFACE_
+#endif // #ifndef YJIT_IFACE_H


### PR DESCRIPTION
For use in development for writing `test.rb` and running with `make
run`.