### PR TITLE
Implement opt_neq

### DIFF
--- a/yjit_codegen.c
+++ b/yjit_codegen.c
@@ -1579,6 +1579,17 @@ gen_opt_eq(jitstate_t* jit, ctx_t* ctx)
 
 static codegen_status_t gen_opt_send_without_block(jitstate_t *jit, ctx_t *ctx);
 
+static codegen_status_t gen_send_general(jitstate_t *jit, ctx_t *ctx, struct rb_call_data *cd, rb_iseq_t *block);
+
+static codegen_status_t
+gen_opt_neq(jitstate_t* jit, ctx_t* ctx)
+{
+    // opt_neq is passed two rb_call_data as arguments:
+    // first for ==, second for !=
+    struct rb_call_data *cd = (struct rb_call_data *)jit_get_arg(jit, 1);
+    return gen_send_general(jit, ctx, cd, NULL);
+}
+
 static codegen_status_t
 gen_opt_aref(jitstate_t *jit, ctx_t *ctx)
 {
@@ -3373,6 +3384,7 @@ yjit_init_codegen(void)
     yjit_reg_op(BIN(opt_ge), gen_opt_ge);
     yjit_reg_op(BIN(opt_gt), gen_opt_gt);
     yjit_reg_op(BIN(opt_eq), gen_opt_eq);
+    yjit_reg_op(BIN(opt_neq), gen_opt_neq);
     yjit_reg_op(BIN(opt_aref), gen_opt_aref);
     yjit_reg_op(BIN(opt_aset), gen_opt_aset);
     yjit_reg_op(BIN(opt_and), gen_opt_and);


### PR DESCRIPTION
Similar to other `opt_` insns, however this takes two call data structs, one for `==` (so we can check if that's specialized) and another for `!=` (the actual method being optimized). The CD for `!=` is the second argument, so I call `gen_send_general` instead of `gen_opt_send_without_block` like we do elsewhere.

This could have been implemented in terms of `rb_opt_equality_specialized`, like we did for `gen_opt_eq` but it's not as common an instruction, I suspect we'll see changes to `gen_opt_eq` in the future, and the hot piece of code I know of in Rails using `!=` (`Concurrent::Map#fetch`) is on an object where `==` is `rb_obj_equal`, so I think it's best to keep this simple for now.