### PR TITLE
Partial revert of ceebc7fc98d

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -2913,7 +2913,7 @@ vm_ccs_free(struct rb_class_cc_entries *ccs, int alive, rb_objspace_t *objspace,
                     asan_poison_object((VALUE)cc);
                 }
             }
-            rb_vm_cc_invalidate(cc);
+            vm_cc_invalidate(cc);
         }
         ruby_xfree(ccs->entries);
     }

--- a/vm_callinfo.h
+++ b/vm_callinfo.h
@@ -410,7 +410,16 @@ vm_cc_method_missing_reason_set(const struct rb_callcache *cc, enum method_missi
     *(enum method_missing_reason *)&cc->aux_.method_missing_reason = reason;
 }
 
-void rb_vm_cc_invalidate(const struct rb_callcache *cc);
+static inline void
+vm_cc_invalidate(const struct rb_callcache *cc)
+{
+    VM_ASSERT(IMEMO_TYPE_P(cc, imemo_callcache));
+    VM_ASSERT(cc != vm_cc_empty());
+    VM_ASSERT(cc->klass != 0); // should be enable
+
+    *(VALUE *)&cc->klass = 0;
+    RB_DEBUG_COUNTER_INC(cc_ent_invalidate);
+}
 
 /* calldata */
 

--- a/vm_method.c
+++ b/vm_method.c
@@ -115,18 +115,6 @@ rb_vm_mtbl_dump(const char *msg, VALUE klass, ID target_mid)
     vm_mtbl_dump(klass, target_mid);
 }
 
-void
-rb_vm_cc_invalidate(const struct rb_callcache *cc)
-{
-    VM_ASSERT(IMEMO_TYPE_P(cc, imemo_callcache));
-    VM_ASSERT(cc != vm_cc_empty());
-    VM_ASSERT(cc->klass != 0); // should be enable
-
-    *(VALUE *)&cc->klass = 0;
-    RB_DEBUG_COUNTER_INC(cc_ent_invalidate);
-}
-
-
 static inline void
 vm_cme_invalidate(rb_callable_method_entry_t *cme)
 {


### PR DESCRIPTION
I'm looking through the places where YJIT needs notifications.  It looks
like these changes to gc.c and vm_callinfo.h have become unnecessary
since 84ab77ba592.  This commit just makes the diff against upstream
smaller, but otherwise shouldn't change any behavior.