### PR TITLE
Allow chaining on immediate guard

### DIFF
--- a/yjit_codegen.c
+++ b/yjit_codegen.c
@@ -942,11 +942,29 @@ gen_jz_to_target0(codeblock_t *cb, uint8_t *target0, uint8_t *target1, uint8_t s
     }
 }
 
+static void
+gen_jbe_to_target0(codeblock_t *cb, uint8_t *target0, uint8_t *target1, uint8_t shape)
+{
+    switch (shape)
+    {
+        case SHAPE_NEXT0:
+        case SHAPE_NEXT1:
+        RUBY_ASSERT(false);
+        break;
+
+        case SHAPE_DEFAULT:
+        jbe_ptr(cb, target0);
+        break;
+    }
+}
+
 enum jcc_kinds {
     JCC_JNE,
     JCC_JNZ,
     JCC_JZ,
     JCC_JE,
+    JCC_JBE,
+    JCC_JNA,
 };
 
 // Generate a jump to a stub that recompiles the current YARV instruction on failure.
@@ -964,6 +982,10 @@ jit_chain_guard(enum jcc_kinds jcc, jitstate_t *jit, const ctx_t *ctx, uint8_t d
         case JCC_JZ:
         case JCC_JE:
             target0_gen_fn = gen_jz_to_target0;
+            break;
+        case JCC_JBE:
+        case JCC_JNA:
+            target0_gen_fn = gen_jbe_to_target0;
             break;
         default:
             RUBY_ASSERT(false && "unimplemented jump kind");
@@ -2258,9 +2280,9 @@ jit_guard_known_klass(jitstate_t *jit, ctx_t *ctx, VALUE known_klass, insn_opnd_
             ADD_COMMENT(cb, "guard not immediate");
             RUBY_ASSERT(Qfalse < Qnil);
             test(cb, REG0, imm_opnd(RUBY_IMMEDIATE_MASK));
-            jnz_ptr(cb, side_exit);
+            jit_chain_guard(JCC_JNZ, jit, ctx, max_chain_depth, side_exit);
             cmp(cb, REG0, imm_opnd(Qnil));
-            jbe_ptr(cb, side_exit);
+            jit_chain_guard(JCC_JBE, jit, ctx, max_chain_depth, side_exit);
 
             ctx_set_opnd_type(ctx, insn_opnd, TYPE_HEAP);
         }


### PR DESCRIPTION
In `jit_guard_known_klass` whenever we encounter a new class should recompile the current instruction.

However, previously once `jit_guard_known_klass` had guarded for a heap object it would not recompile for  any immediate (special const) objects arriving afterwards and would take a plain side-exit instead of a chain guard.

[I made a gist demonstrating this issue](https://gist.github.com/jhawthorn/9d6280eae4ae21339ed63ba6ff624ece). When we see `nil` first and the heap object second we successfully generate 4 blocks and don't side exit. When we see the heap object first we never compile the version of the block for `nil` and side exit instead.

This is also demonstrated in a test in #103:
https://github.com/Shopify/yjit/blob/85be28e332fb4760461b3972862d870246913c89/test/ruby/test_yjit.rb#L58-L79

This commit uses `jit_chain_guard` inside `jit_guard_known_klass` instead of the plain side exit, so that we can recompile for any special constants arriving afterwards. With this change both versions of my test gist compile 4 blocks and have no side-exits.

---

I was a little unsure of this approach at first, having each of the three guards (`x & IMM_MASK`, `x <= Qnil`, `x.class == known`) jump to a different stub seemed wasteful. What I didn't grok initially (had a helpful hint from @maximecb) is that having the separate targets _does_ allow us to "learn" more information about the receiving value, even if we don't set explicit typing information in the branch (though we maybe could in the future? more later). Since we're only going to reach those stubs after going through the unique jump we implicitly get "information" from the values arriving to that stub and having their checks recompiled there (neat!).

(maybe rambling a bit here) As I mentioned, this doesn't set type information when branching, at this point I don't think anything would take advantage of it. In the future it feels like there's opportunity here, particularly with the comparison against `Qnil` could differentiate between heap values, Qnil, and Qfalse in one comparison and two jumps. We could also probably avoid the check after going through a `branchif` or `branchunless` if we recorded that that the type could not be a "falsy". This is all definitely out of scope for this PR though.

Another potential concern with this is that this is now a tree instead of a linear chain guarding the class, which might not fit the existing meaning of `SEND_MAX_DEPTH`? (or maybe it does? trees have depth) There's fortunately a small finite number of types of special constants. I think it's okay but maybe that needs to be made clearer as our behaviour.