### PR TITLE
Add an lldb script to print YJIT comments

### DIFF
--- a/misc/lldb_yjit.py
+++ b/misc/lldb_yjit.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+#coding: utf-8
+#
+# Usage: run `command script import -r misc/lldb_yjit.py` on LLDB
+#
+
+from __future__ import print_function
+import lldb
+import os
+import shlex
+
+def list_comments(debugger, command, result, internal_dict):
+    target = debugger.GetSelectedTarget()
+    process = target.GetProcess()
+    thread = process.GetSelectedThread()
+    frame = thread.GetSelectedFrame()
+
+    # Get the different types we need
+    rb_darray_meta_t = target.FindFirstType("rb_darray_meta_t")
+    codeblock_t = target.FindFirstType("codeblock_t")
+    yjit_comment = target.FindFirstType("yjit_comment")
+
+    # Get the global variables we need
+    comments = target.FindFirstGlobalVariable("yjit_code_comments")
+    cb = target.FindFirstGlobalVariable("cb").Cast(codeblock_t.GetPointerType())
+
+    # Get the address of the memory block we're using
+    mem_addr = cb.GetChildMemberWithName("mem_block").GetValueAsUnsigned()
+
+    # Find the size of the darray comment list
+    meta = comments.Cast(rb_darray_meta_t.GetPointerType())
+    size = meta.GetChildMemberWithName("size").GetValueAsUnsigned()
+
+    # Get the address of the block following the metadata header
+    t_offset = comments.GetValueAsUnsigned() + rb_darray_meta_t.GetByteSize()
+
+    # Loop through each comment and print
+    for t in range(0, size):
+        addr = lldb.SBAddress(t_offset + (t * yjit_comment.GetByteSize()), target)
+        comment = target.CreateValueFromAddress("yjit_comment", addr, yjit_comment)
+        string = comment.GetChildMemberWithName("comment")
+        comment_offset = mem_addr + comment.GetChildMemberWithName("offset").GetValueAsUnsigned()
+        print("%0#x %s" % (comment_offset, string.GetSummary()), file = result)
+
+
+def __lldb_init_module(debugger, internal_dict):
+    debugger.HandleCommand("command script add -f lldb_yjit.list_comments lc")


### PR DESCRIPTION
This script is an lldb helper that just loops through all the comments
stored and prints out the comment along with the address corresponding
to the comment.

For example, I'm crashing in JIT code at address 0x0000000110000168.
Using the `lc` helper I can see that it's probably crashing inside the
exit back to the interpreter

```
(lldb) bt 5
* thread #1, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=1, address=0x22220021)
    frame #0: 0x0000000110000168
  * frame #1: 0x00000001002b5ff5 miniruby`invoke_block_from_c_bh [inlined] invoke_block(ec=0x0000000100e05350, iseq=0x0000000100c1ff10, self=0x0000000100c76cc0, captured=<unavailable>, cref=0x0000000000000000, type=<unavailable>, opt_pc=<unavailable>) at vm.c:1268:12
    frame #2: 0x00000001002b5f7d miniruby`invoke_block_from_c_bh [inlined] invoke_iseq_block_from_c(ec=<unavailable>, captured=<unavailable>, self=0x0000000100c76cc0, argc=2, argv=<unavailable>, kw_splat=0, passed_block_handler=0x0000000000000000, cref=0x0000000000000000, is_lambda=<unavailable>, me=0x0000000000000000) at vm.c:1340
    frame #3: 0x00000001002b5e14 miniruby`invoke_block_from_c_bh(ec=<unavailable>, block_handler=<unavailable>, argc=<unavailable>, argv=<unavailable>, kw_splat=0, passed_block_handler=0x0000000000000000, cref=0x0000000000000000, is_lambda=<unavailable>, force_blockarg=0) at vm.c:1358
    frame #4: 0x000000010029860b miniruby`rb_yield_values(n=<unavailable>) at vm_eval.c:0
(lldb) lc
0x11000006d "putobject_INT2FIX_1_"
0x110000083 "leave"
0x110000087 "check for interrupts"
0x110000087 "RUBY_VM_CHECK_INTS(ec)"
0x110000098 "check for finish frame"
0x1100000ed "getlocal_WC_0"
0x110000107 "getlocal_WC_1"
0x11000012a "opt_send_without_block"
0x110000139 "opt_send_without_block"
0x11000013c "exit to interpreter"
```