### PR TITLE
Demonstration of bug: ctx_set_opnd_type in jit_rb_obj_not corrupts types

### DIFF
--- a/yjit_codegen.c
+++ b/yjit_codegen.c
@@ -2407,18 +2407,19 @@ static bool
 jit_rb_obj_not(jitstate_t *jit, ctx_t *ctx, const struct rb_callinfo *ci, const rb_callable_method_entry_t *cme, rb_iseq_t *block, const int32_t argc)
 {
     const val_type_t recv_opnd = ctx_get_opnd_type(ctx, OPND_STACK(0));
-    x86opnd_t out_opnd = ctx_stack_opnd(ctx, 0);
 
     if (recv_opnd.type == ETYPE_NIL || recv_opnd.type == ETYPE_FALSE) {
         ADD_COMMENT(cb, "rb_obj_not(nil_or_false)");
+        ctx_stack_pop(ctx, 1);
+        x86opnd_t out_opnd = ctx_stack_push(ctx, TYPE_TRUE);
         mov(cb, out_opnd, imm_opnd(Qtrue));
-        ctx_set_opnd_type(ctx, OPND_STACK(0), TYPE_TRUE);
     }
     else if (recv_opnd.is_heap || recv_opnd.type != ETYPE_UNKNOWN) {
         // Note: recv_opnd.type != ETYPE_NIL && recv_opnd.type != ETYPE_FALSE.
         ADD_COMMENT(cb, "rb_obj_not(truthy)");
+        ctx_stack_pop(ctx, 1);
+        x86opnd_t out_opnd = ctx_stack_push(ctx, TYPE_FALSE);
         mov(cb, out_opnd, imm_opnd(Qfalse));
-        ctx_set_opnd_type(ctx, OPND_STACK(0), TYPE_FALSE);
     }
     else {
         // jit_guard_known_klass() already ran on the receiver which should


### PR DESCRIPTION
When we've pushed a local onto the stack, `ctx_set_opnd_type` will not only set the type of the stack, but also of the local variable it came from. This is an issue in `jit_rb_obj_not` as it would incorrectly "learn" that any truthy value was `Qfalse`.

Because in most places we check comptime values first, this mostly just resulted in extra type checks:
```
foo = 123
!foo
!foo
```

```
== BLOCK 1/5: 38 BYTES, ISEQ RANGE [0,8) =======================================
  ; putobject
  5648fb04205d:  mov    qword ptr [rdx], 0xf7
  ; setlocal_WC_0
  5648fb042064:  mov    rax, qword ptr [rdi + 0x20]
  5648fb042068:  test   byte ptr [rax], 8
  5648fb04206b:  jne    0x564903042000
  5648fb042071:  mov    rcx, qword ptr [rdx]
  5648fb042074:  mov    qword ptr [rax - 0x18], rcx
  ; getlocal_WC_0
  5648fb042078:  mov    rax, qword ptr [rdi + 0x20]
  5648fb04207c:  mov    rax, qword ptr [rax - 0x18]
  5648fb042080:  mov    qword ptr [rdx], rax
== BLOCK 2/5: 10 BYTES, ISEQ RANGE [6,8) =======================================
  ; opt_not
  5648fb042083:  mov    rax, qword ptr [rdx]
  ; rb_obj_not(truthy)
  5648fb042086:  mov    qword ptr [rdx], 0
== BLOCK 3/5: 11 BYTES, ISEQ RANGE [8,13) ======================================
  ; pop
  ; getlocal_WC_0
  5648fb04208d:  mov    rax, qword ptr [rdi + 0x20]
  5648fb042091:  mov    rax, qword ptr [rax - 0x18]
  5648fb042095:  mov    qword ptr [rdx], rax
== BLOCK 4/5: 19 BYTES, ISEQ RANGE [11,13) =====================================
  ; opt_not
  5648fb042098:  mov    rax, qword ptr [rdx]
  ; guard object is fixnum -- Extra type check because types were corrupted!
  5648fb04209b:  test   al, 1
  5648fb04209e:  je     0x5649030420b5
  ; rb_obj_not(truthy)
  5648fb0420a4:  mov    qword ptr [rdx], 0
```

This PR uses `ctx_stack_pop` and `ctx_stack_push` to fix the issue in `jit_rb_obj_not`. This avoids the extra type check. This also adds assertions which would have previously failed to detect type corruption from `jit_guard_known_klass`.

I believe this same issue exists in `swap` and `setn` (I _feel_ like this could cause a segv if we confused a heap with an immediate), but in this case it doesn't feel right to just set the locals, I feel like we should be transferring the temp mappings to the locals so that we can still learn.

I also think there's an issue clearing the local types which I'll open a separate PR for.