### PR TITLE
Flatten mappings when clearing locals

### DIFF
--- a/yjit_core.c
+++ b/yjit_core.c
@@ -201,6 +201,16 @@ void ctx_set_local_type(ctx_t* ctx, size_t idx, val_type_t type)
 // eg: because of a call we can't track
 void ctx_clear_local_types(ctx_t* ctx)
 {
+    // When clearing local types we must detach any stack mappings to those
+    // locals. Even if local values may have changed, stack values will not.
+    for (int i = 0; i < ctx->stack_size && i < MAX_LOCAL_TYPES; i++) {
+        temp_mapping_t *mapping = &ctx->temp_mapping[i];
+        if (mapping->kind == TEMP_LOCAL) {
+            RUBY_ASSERT(mapping->idx < MAX_LOCAL_TYPES);
+            ctx->temp_types[i] = ctx->local_types[mapping->idx];
+            *mapping = MAP_STACK;
+        }
+    }
     memset(&ctx->local_types, 0, sizeof(ctx->local_types));
 }
 


### PR DESCRIPTION
We clear locals when we know their values might change (ex. when performing a method call). However previously values on the stack which were originally pushed from a local would still point back to that local.

With this commit, when clearing locals, we'll now iterate over the mappings of the stack and copy the known type from the local to the stack mapping, removing the association to the local.

This should mean both that we'll retain any information we already know about the local type, and that if a local is modified we won't incorrectly infer it's new type from the existing value on the stack.

We can see this issue by looking at addition block of


``` ruby
foo = 1
foo + 2.itself
```

`itself` is a method call so it will clear all the local types, and so we forget the known value of `1` which was already on the stack and need to re-test it for being a fixnum.

```
== BLOCK 3/3: 93 BYTES, ISEQ RANGE [8,11) ======================================
  ; opt_plus
  ; guard arg0 fixnum
  55ed548cc12f:  test   byte ptr [rdx], 1
  55ed548cc132:  je     0x55ed5c8cc08f
  ; guard arg1 fixnum
  55ed548cc138:  test   byte ptr [rdx + 8], 1
  55ed548cc13c:  je     0x55ed5c8cc08f
  55ed548cc142:  mov    rax, qword ptr [rdx]
  55ed548cc145:  sub    rax, 1
  55ed548cc149:  add    rax, qword ptr [rdx + 8]
  55ed548cc14d:  jo     0x55ed5c8cc08f
  55ed548cc153:  mov    qword ptr [rdx], rax
```

After this commit we only check arg1 being a fixnum (YJIT has no idea what type `itself` returns), not arg0.