### PR TITLE
rb_struct_define_under needs a trailing NULL

### DIFF
--- a/yjit_iface.c
+++ b/yjit_iface.c
@@ -1035,7 +1035,7 @@ rb_yjit_init(struct rb_yjit_options *options)
     rb_define_method(cYjitDisasm, "disasm", yjit_disasm, 2);
     cYjitDisasmInsn = rb_struct_define_under(cYjitDisasm, "Insn", "address", "mnemonic", "op_str", NULL);
 #if RUBY_DEBUG
-    cYjitCodeComment = rb_struct_define_under(cYjitDisasm, "Comment", "address", "comment");
+    cYjitCodeComment = rb_struct_define_under(cYjitDisasm, "Comment", "address", "comment", NULL);
 #endif
 #endif
 


### PR DESCRIPTION
The last parameter to rb_struct_define_under needs to be NULL otherwise
we can get a SEGV.