### PR TITLE
Revert "Flatten mappings when clearing locals"

### DIFF
--- a/yjit_core.c
+++ b/yjit_core.c
@@ -201,16 +201,6 @@ void ctx_set_local_type(ctx_t* ctx, size_t idx, val_type_t type)
 // eg: because of a call we can't track
 void ctx_clear_local_types(ctx_t* ctx)
 {
-    // When clearing local types we must detach any stack mappings to those
-    // locals. Even if local values may have changed, stack values will not.
-    for (int i = 0; i < ctx->stack_size && i < MAX_LOCAL_TYPES; i++) {
-        temp_mapping_t *mapping = &ctx->temp_mapping[i];
-        if (mapping->kind == TEMP_LOCAL) {
-            RUBY_ASSERT(mapping->idx < MAX_LOCAL_TYPES);
-            ctx->temp_types[i] = ctx->local_types[mapping->idx];
-            *mapping = MAP_STACK;
-        }
-    }
     memset(&ctx->local_types, 0, sizeof(ctx->local_types));
 }
 


### PR DESCRIPTION
This reverts commit b195671aaee02c73cfcd40658b01d70f33f622ee.

We're getting CI failures on other branches and I'm trying to identify the cause.