### PR TITLE
Save PC and SP before accessing globals

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -7,6 +7,19 @@ assert_equal 'string', %q{
   foo
 }
 
+# Check that exceptions work when setting global variables
+assert_equal 'rescued', %q{
+  def set_var
+    $var = 100
+  rescue
+    :rescued
+  end
+
+  set_var
+  trace_var(:$var) { raise }
+  set_var
+}
+
 # Check that global variables work
 assert_equal 'string', %q{
   $foo = "string"
@@ -16,6 +29,25 @@ assert_equal 'string', %q{
   end
 
   foo
+}
+
+# Check that exceptions work when getting global variable
+assert_equal 'rescued', %q{
+  module Warning
+    def warn(message)
+      raise
+    end
+  end
+
+  def get_var
+    $=
+  rescue
+    :rescued
+  end
+
+  $VERBOSE = true
+  get_var
+  get_var
 }
 
 # Check that global tracepoints work


### PR DESCRIPTION
These instructions are marked as not leaf in insns.def, which indicate
that they could raise exceptions and/or call Ruby methods.