### PR TITLE
Implement ir_and, ir_not, ir_sub

### DIFF
--- a/yjit_backend.h
+++ b/yjit_backend.h
@@ -103,7 +103,7 @@ enum yjit_ir_op
     // Arithmetic instructions
     OP_ADD,
     OP_SUB,
-    OP_MUL,
+    // OP_MUL,
     OP_AND,
     OP_NOT,
 


### PR DESCRIPTION
Works by moving the `add` logic into a function that accepts a pointer to an x86 writer function, then calls the same kind of code for each operation type.