### PR TITLE
Add verify_ctx to validate learned types against received types

### DIFF
--- a/yjit_codegen.c
+++ b/yjit_codegen.c
@@ -127,9 +127,17 @@ jit_type_of_value(VALUE val)
             return TYPE_FIXNUM;
         } else if (NIL_P(val)) {
             return TYPE_NIL;
+        } else if (val == Qtrue) {
+            return TYPE_TRUE;
+        } else if (val == Qfalse) {
+            return TYPE_FALSE;
+        } else if (STATIC_SYM_P(val)) {
+            return TYPE_STATIC_SYMBOL;
+        } else if (FLONUM_P(val)) {
+            return TYPE_FLONUM;
         } else {
-            // generic immediate
-            return TYPE_IMM;
+            RUBY_ASSERT(false);
+            UNREACHABLE_RETURN(TYPE_IMM);
         }
     } else {
         switch (BUILTIN_TYPE(val)) {

--- a/yjit_codegen.c
+++ b/yjit_codegen.c
@@ -130,42 +130,6 @@ jit_peek_at_local(jitstate_t *jit, ctx_t *ctx, int n)
     return ep[-VM_ENV_DATA_SIZE - local_table_size + n + 1];
 }
 
-// When we know a VALUE to be static, this returns an appropriate val_type_t
-static val_type_t
-jit_type_of_value(VALUE val)
-{
-    if (SPECIAL_CONST_P(val)) {
-        if (FIXNUM_P(val)) {
-            return TYPE_FIXNUM;
-        } else if (NIL_P(val)) {
-            return TYPE_NIL;
-        } else if (val == Qtrue) {
-            return TYPE_TRUE;
-        } else if (val == Qfalse) {
-            return TYPE_FALSE;
-        } else if (STATIC_SYM_P(val)) {
-            return TYPE_STATIC_SYMBOL;
-        } else if (FLONUM_P(val)) {
-            return TYPE_FLONUM;
-        } else {
-            RUBY_ASSERT(false);
-            UNREACHABLE_RETURN(TYPE_IMM);
-        }
-    } else {
-        switch (BUILTIN_TYPE(val)) {
-            case T_ARRAY:
-               return TYPE_ARRAY;
-            case T_HASH:
-               return TYPE_HASH;
-            case T_STRING:
-               return TYPE_STRING;
-            default:
-                // generic heap object
-                return TYPE_HEAP;
-        }
-    }
-}
-
 // Save the incremented PC on the CFP
 // This is necessary when calleees can raise or allocate
 static void
@@ -252,14 +216,14 @@ verify_ctx(jitstate_t *jit, ctx_t *ctx)
     RUBY_ASSERT(jit_at_current_insn(jit));
 
     VALUE self_val = jit_peek_at_self(jit, ctx);
-    if (type_diff(jit_type_of_value(self_val), ctx->self_type) == INT_MAX) {
+    if (type_diff(yjit_type_of_value(self_val), ctx->self_type) == INT_MAX) {
         rb_bug("verify_ctx: ctx type (%s) incompatible with actual value of self: %s", yjit_type_name(ctx->self_type), rb_obj_info(self_val));
     }
 
     for (int i = 0; i < ctx->stack_size && i < MAX_TEMP_TYPES; i++) {
         temp_type_mapping_t learned = ctx_get_opnd_mapping(ctx, OPND_STACK(i));
         VALUE val = jit_peek_at_stack(jit, ctx, i);
-        val_type_t detected = jit_type_of_value(val);
+        val_type_t detected = yjit_type_of_value(val);
 
         if (learned.mapping.kind == TEMP_SELF) {
             if (self_val != val) {
@@ -293,7 +257,7 @@ verify_ctx(jitstate_t *jit, ctx_t *ctx)
     for (int i = 0; i < local_table_size && i < MAX_TEMP_TYPES; i++) {
         val_type_t learned = ctx->local_types[i];
         VALUE val = jit_peek_at_local(jit, ctx, i);
-        val_type_t detected = jit_type_of_value(val);
+        val_type_t detected = yjit_type_of_value(val);
 
         if (type_diff(detected, learned) == INT_MAX) {
             rb_bug("verify_ctx: ctx type (%s) incompatible with actual value of local: %s", yjit_type_name(learned), rb_obj_info(val));
@@ -991,7 +955,7 @@ gen_putobject(jitstate_t* jit, ctx_t* ctx)
         VALUE put_val = jit_get_arg(jit, 0);
         jit_mov_gc_ptr(jit, cb, REG0, put_val);
 
-        val_type_t val_type = jit_type_of_value(put_val);
+        val_type_t val_type = yjit_type_of_value(put_val);
 
         // Write argument at SP
         x86opnd_t stack_top = ctx_stack_push(ctx, val_type);
@@ -3630,7 +3594,7 @@ gen_opt_getinlinecache(jitstate_t *jit, ctx_t *ctx)
     // FIXME: This leaks when st_insert raises NoMemoryError
     assume_stable_global_constant_state(jit->block);
 
-    val_type_t type = jit_type_of_value(ice->value);
+    val_type_t type = yjit_type_of_value(ice->value);
     x86opnd_t stack_top = ctx_stack_push(ctx, type);
     jit_mov_gc_ptr(jit, cb, REG0, ice->value);
     mov(cb, stack_top, REG0);

--- a/yjit_codegen.c
+++ b/yjit_codegen.c
@@ -118,6 +118,18 @@ jit_peek_at_self(jitstate_t *jit, ctx_t *ctx)
     return jit->ec->cfp->self;
 }
 
+static VALUE
+jit_peek_at_local(jitstate_t *jit, ctx_t *ctx, int n)
+{
+    RUBY_ASSERT(jit_at_current_insn(jit));
+
+    int32_t local_table_size = jit->iseq->body->local_table_size;
+    RUBY_ASSERT(n < (int)jit->iseq->body->local_table_size);
+
+    const VALUE *ep = jit->ec->cfp->ep;
+    return ep[-VM_ENV_DATA_SIZE - local_table_size + n + 1];
+}
+
 // When we know a VALUE to be static, this returns an appropriate val_type_t
 static val_type_t
 jit_type_of_value(VALUE val)
@@ -231,11 +243,70 @@ _add_comment(codeblock_t* cb, const char* comment_str)
 #define ADD_COMMENT(cb, comment) _add_comment((cb), (comment))
 yjit_comment_array_t yjit_code_comments;
 
+// Verify the ctx's types and mappings against the compile-time stack, self,
+// and locals.
+static void
+verify_ctx(jitstate_t *jit, ctx_t *ctx)
+{
+    // Only able to check types when at current insn
+    RUBY_ASSERT(jit_at_current_insn(jit));
+
+    VALUE self_val = jit_peek_at_self(jit, ctx);
+    if (type_diff(jit_type_of_value(self_val), ctx->self_type) == INT_MAX) {
+        rb_bug("verify_ctx: ctx type (%s) incompatible with actual value of self: %s", yjit_type_name(ctx->self_type), rb_obj_info(self_val));
+    }
+
+    for (int i = 0; i < ctx->stack_size && i < MAX_TEMP_TYPES; i++) {
+        temp_type_mapping_t learned = ctx_get_opnd_mapping(ctx, OPND_STACK(i));
+        VALUE val = jit_peek_at_stack(jit, ctx, i);
+        val_type_t detected = jit_type_of_value(val);
+
+        if (learned.mapping.kind == TEMP_SELF) {
+            if (self_val != val) {
+                rb_bug("verify_ctx: stack value was mapped to self, but values did not match\n"
+                        "  stack: %s\n"
+                        "  self: %s",
+                        rb_obj_info(val),
+                        rb_obj_info(self_val));
+            }
+        }
+
+        if (learned.mapping.kind == TEMP_LOCAL) {
+            int local_idx = learned.mapping.idx;
+            VALUE local_val = jit_peek_at_local(jit, ctx, local_idx);
+            if (local_val != val) {
+                rb_bug("verify_ctx: stack value was mapped to local, but values did not match\n"
+                        "  stack: %s\n"
+                        "  local %i: %s",
+                        rb_obj_info(val),
+                        local_idx,
+                        rb_obj_info(local_val));
+            }
+        }
+
+        if (type_diff(detected, learned.type) == INT_MAX) {
+            rb_bug("verify_ctx: ctx type (%s) incompatible with actual value on stack: %s", yjit_type_name(learned.type), rb_obj_info(val));
+        }
+    }
+
+    int32_t local_table_size = jit->iseq->body->local_table_size;
+    for (int i = 0; i < local_table_size && i < MAX_TEMP_TYPES; i++) {
+        val_type_t learned = ctx->local_types[i];
+        VALUE val = jit_peek_at_local(jit, ctx, i);
+        val_type_t detected = jit_type_of_value(val);
+
+        if (type_diff(detected, learned) == INT_MAX) {
+            rb_bug("verify_ctx: ctx type (%s) incompatible with actual value of local: %s", yjit_type_name(learned), rb_obj_info(val));
+        }
+    }
+}
+
 #else
 
 #define GEN_COUNTER_INC(cb, counter_name) ((void)0)
 #define COUNTED_EXIT(side_exit, counter_name) side_exit
 #define ADD_COMMENT(cb, comment) ((void)0)
+#define verify_ctx(jit, ctx) ((void)0)
 
 #endif // if RUBY_DEBUG
 
@@ -482,6 +553,11 @@ yjit_gen_block(block_t *block, rb_execution_context_t *ec)
         jit.insn_idx = insn_idx;
         jit.pc = pc;
         jit.opcode = opcode;
+
+        // Verify our existing assumption (DEBUG)
+        if (jit_at_current_insn(&jit)) {
+            verify_ctx(&jit, ctx);
+        }
 
         // Lookup the codegen function for this instruction
         codegen_fn gen_fn = gen_fns[opcode];

--- a/yjit_core.c
+++ b/yjit_core.c
@@ -285,6 +285,43 @@ void ctx_clear_local_types(ctx_t* ctx)
     memset(&ctx->local_types, 0, sizeof(ctx->local_types));
 }
 
+
+/* This returns an appropriate val_type_t based on a known value */
+val_type_t
+yjit_type_of_value(VALUE val)
+{
+    if (SPECIAL_CONST_P(val)) {
+        if (FIXNUM_P(val)) {
+            return TYPE_FIXNUM;
+        } else if (NIL_P(val)) {
+            return TYPE_NIL;
+        } else if (val == Qtrue) {
+            return TYPE_TRUE;
+        } else if (val == Qfalse) {
+            return TYPE_FALSE;
+        } else if (STATIC_SYM_P(val)) {
+            return TYPE_STATIC_SYMBOL;
+        } else if (FLONUM_P(val)) {
+            return TYPE_FLONUM;
+        } else {
+            RUBY_ASSERT(false);
+            UNREACHABLE_RETURN(TYPE_IMM);
+        }
+    } else {
+        switch (BUILTIN_TYPE(val)) {
+            case T_ARRAY:
+               return TYPE_ARRAY;
+            case T_HASH:
+               return TYPE_HASH;
+            case T_STRING:
+               return TYPE_STRING;
+            default:
+                // generic heap object
+                return TYPE_HEAP;
+        }
+    }
+}
+
 /* The name of a type, for debugging */
 const char *
 yjit_type_name(val_type_t type)

--- a/yjit_core.c
+++ b/yjit_core.c
@@ -614,6 +614,12 @@ block_t* gen_block_version(blockid_t blockid, const ctx_t* start_ctx, rb_executi
 // Generate a block version that is an entry point inserted into an iseq
 uint8_t* gen_entry_point(const rb_iseq_t *iseq, uint32_t insn_idx, rb_execution_context_t *ec)
 {
+    // If we aren't at PC 0, don't generate code
+    // See yjit_pc_guard
+    if (iseq->body->iseq_encoded != ec->cfp->pc) {
+        return NULL;
+    }
+
     // The entry context makes no assumptions about types
     blockid_t blockid = { iseq, insn_idx };
 

--- a/yjit_core.c
+++ b/yjit_core.c
@@ -34,6 +34,8 @@ ctx_stack_push_mapping(ctx_t* ctx, temp_type_mapping_t mapping)
         ctx->temp_types[ctx->stack_size] = mapping.type;
 
         RUBY_ASSERT(mapping.mapping.kind != TEMP_LOCAL || mapping.mapping.idx < MAX_LOCAL_TYPES);
+        RUBY_ASSERT(mapping.mapping.kind != TEMP_STACK || mapping.mapping.idx == 0);
+        RUBY_ASSERT(mapping.mapping.kind != TEMP_SELF || mapping.mapping.idx == 0);
     }
 
     ctx->stack_size += 1;
@@ -156,7 +158,6 @@ ctx_get_opnd_type(const ctx_t* ctx, insn_opnd_t opnd)
     rb_bug("unreachable");
 }
 
-int type_diff(val_type_t src, val_type_t dst);
 #define UPGRADE_TYPE(dest, src) do { \
     RUBY_ASSERT(type_diff((src), (dest)) != INT_MAX); \
     (dest) = (src); \
@@ -282,6 +283,44 @@ void ctx_clear_local_types(ctx_t* ctx)
         RUBY_ASSERT(mapping->kind == TEMP_STACK || mapping->kind == TEMP_SELF);
     }
     memset(&ctx->local_types, 0, sizeof(ctx->local_types));
+}
+
+/* The name of a type, for debugging */
+const char *
+yjit_type_name(val_type_t type)
+{
+    RUBY_ASSERT(!(type.is_imm && type.is_heap));
+
+    switch (type.type) {
+        case ETYPE_UNKNOWN:
+            if (type.is_imm) {
+                return "unknown immediate";
+            } else if (type.is_heap) {
+                return "unknown heap";
+            } else {
+                return "unknown";
+            }
+        case ETYPE_NIL:
+            return "nil";
+        case ETYPE_TRUE:
+            return "true";
+        case ETYPE_FALSE:
+            return "false";
+        case ETYPE_FIXNUM:
+            return "fixnum";
+        case ETYPE_FLONUM:
+            return "flonum";
+        case ETYPE_ARRAY:
+            return "array";
+        case ETYPE_HASH:
+            return "hash";
+        case ETYPE_SYMBOL:
+            return "symbol";
+        case ETYPE_STRING:
+            return "string";
+    }
+
+    UNREACHABLE_RETURN("");
 }
 
 /*

--- a/yjit_core.h
+++ b/yjit_core.h
@@ -272,6 +272,7 @@ void ctx_set_local_type(ctx_t* ctx, size_t idx, val_type_t type);
 void ctx_clear_local_types(ctx_t* ctx);
 int ctx_diff(const ctx_t* src, const ctx_t* dst);
 int type_diff(val_type_t src, val_type_t dst);
+val_type_t yjit_type_of_value(VALUE val);
 const char *yjit_type_name(val_type_t type);
 
 temp_type_mapping_t ctx_get_opnd_mapping(const ctx_t* ctx, insn_opnd_t opnd);

--- a/yjit_core.h
+++ b/yjit_core.h
@@ -271,6 +271,8 @@ void ctx_upgrade_opnd_type(ctx_t* ctx, insn_opnd_t opnd, val_type_t type);
 void ctx_set_local_type(ctx_t* ctx, size_t idx, val_type_t type);
 void ctx_clear_local_types(ctx_t* ctx);
 int ctx_diff(const ctx_t* src, const ctx_t* dst);
+int type_diff(val_type_t src, val_type_t dst);
+const char *yjit_type_name(val_type_t type);
 
 temp_type_mapping_t ctx_get_opnd_mapping(const ctx_t* ctx, insn_opnd_t opnd);
 void ctx_set_opnd_mapping(ctx_t* ctx, insn_opnd_t opnd, temp_type_mapping_t type_mapping);


### PR DESCRIPTION
An earlier version of this helped track down some of the issues fixed by https://github.com/Shopify/yjit/pull/139

This adds a `verify_ctx` method, which, when RUBY_DEBUG is enabled, checks that the detected types of the values on the stack, locals, and self are compatible with the actual compile-time types. I think this could still provide some value in the future to ensure our type bookkeeping is correct (at least against the values we see at compile-time).

This also found an issue (though I'm not sure the code could ever be executed due to the pc_is_zero guard) where when encountering optargs we could call `yjit_gen_block` with a `starting_insn_idx` which did not match our actual current PC from ec.

For this to work `jit_type_of_value` needs to find as specific types as the other guards do (which it should be able to, as it has the actual current value) so that has been updated (which we probably want anyways 🙂)