### PR TITLE
Backend feedback and updates

### DIFF
--- a/yjit_backend.h
+++ b/yjit_backend.h
@@ -88,6 +88,7 @@ STATIC_ASSERT(ir_opnd_size, sizeof(ir_opnd_t) <= 16);
 #define IR_REG(x86reg) ( (ir_opnd_t){ .num_bits = 64, .kind = EIR_REG, .as.reg.idx = x86reg.as.reg.reg_no } )
 
 ir_opnd_t ir_code_ptr(uint8_t* code_ptr);
+ir_opnd_t ir_const_ptr(void *ptr);
 ir_opnd_t ir_imm(int64_t val);
 ir_opnd_t ir_mem(uint8_t num_bits, ir_opnd_t base, int32_t disp);
 
@@ -130,6 +131,7 @@ enum yjit_ir_op
     // TODO:
     //CALL_CFUNC (var-arg...)
     OP_RET,
+    OP_RETVAL,
 
     //COUNTER_INC (counter_name)
 


### PR DESCRIPTION
This PR does a couple of things:

* Adds some nicer printing for the instructions using ANSI escape sequences.
* Adds comments as an instruction to the IR. These are basically just copied over between each optimization/allocation pass. When we go to print them out we have some special handling. When we go to generate X86 we just skip over them.
* Support return with an optional value. This makes it a lot simpler to actually return values from functions, and is a necessary step to make it so that you don't have to know about RAX in order to generate IR. Now you can use the OP_RETVAL operation to return values without explicitly moving the value into RAX (which is now done in the ir_gen_x86 pass).
* Buffer the instruction arrays by swapping between them when optimizing/allocating. This makes it more obvious how to do other passes through the IR (as evidenced by the ir_peephole_opt function that doesn't actually do anything at the moment).
* Add support for arbitrary void pointers. This will make it easier to point to random structs that we need to pull values out of, but also can be/is used for comments in the IR.