### PR TITLE
Implement putspecialobject 

### DIFF
--- a/test/ruby/test_yjit.rb
+++ b/test/ruby/test_yjit.rb
@@ -59,6 +59,10 @@ class TestYJIT < Test::Unit::TestCase
     assert_compiles('$foo = 123; $foo', insns: %i[setglobal], result: 123)
   end
 
+  def test_compile_putspecialobject
+    assert_compiles('-> {}', insns: %i[putspecialobject])
+  end
+
   def test_compile_tostring
     assert_no_exits('"i am a string #{true}"')
   end
@@ -191,7 +195,7 @@ class TestYJIT < Test::Unit::TestCase
 
       iseq = RubyVM::InstructionSequence.of(_test_proc)
       IO.open(3).write Marshal.dump({
-        result: result,
+        result: #{result == ANY ? "nil" : "result"},
         stats: stats,
         iseqs: collect_iseqs(iseq),
         disasm: iseq.disasm

--- a/yjit_codegen.c
+++ b/yjit_codegen.c
@@ -986,6 +986,23 @@ gen_putself(jitstate_t* jit, ctx_t* ctx)
     return YJIT_KEEP_COMPILING;
 }
 
+static codegen_status_t
+gen_putspecialobject(jitstate_t* jit, ctx_t* ctx)
+{
+    enum vm_special_object_type type = (enum vm_special_object_type)jit_get_arg(jit, 0);
+
+    if (type == VM_SPECIAL_OBJECT_VMCORE) {
+        x86opnd_t stack_top = ctx_stack_push(ctx, TYPE_HEAP);
+        jit_mov_gc_ptr(jit, cb, REG0, rb_mRubyVMFrozenCore);
+        mov(cb, stack_top, REG0);
+        return YJIT_KEEP_COMPILING;
+    } else {
+        // TODO: implement for VM_SPECIAL_OBJECT_CBASE and
+        // VM_SPECIAL_OBJECT_CONST_BASE
+        return YJIT_CANT_COMPILE;
+    }
+}
+
 // Compute the index of a local variable from its slot index
 static uint32_t
 slot_to_local_idx(const rb_iseq_t *iseq, int32_t slot_idx)
@@ -3685,6 +3702,7 @@ yjit_init_codegen(void)
     yjit_reg_op(BIN(putobject_INT2FIX_0_), gen_putobject_int2fix);
     yjit_reg_op(BIN(putobject_INT2FIX_1_), gen_putobject_int2fix);
     yjit_reg_op(BIN(putself), gen_putself);
+    yjit_reg_op(BIN(putspecialobject), gen_putspecialobject);
     yjit_reg_op(BIN(getlocal), gen_getlocal);
     yjit_reg_op(BIN(getlocal_WC_0), gen_getlocal_wc0);
     yjit_reg_op(BIN(getlocal_WC_1), gen_getlocal_wc1);


### PR DESCRIPTION
This only adds the case for `VM_SPECIAL_OBJECT_VMCORE` (because it's trivial, and I believe the most common).

This is used for building lambdas and some other behaviour (merging hashes, arrays, raising exceptions)