### PR TITLE
Use cmov to handle Qundef case in getivar instead of side-exit

### DIFF
--- a/yjit_codegen.c
+++ b/yjit_codegen.c
@@ -1451,10 +1451,9 @@ gen_get_ivar(jitstate_t *jit, ctx_t *ctx, const int max_chain_depth, VALUE compt
             mov(cb, REG1, ivar_opnd);
 
             // Guard that the variable is not Qundef
-            // TODO: use cmov to push Qnil in this case
-            ADD_COMMENT(cb, "guard value not Qundef");
             cmp(cb, REG1, imm_opnd(Qundef));
-            je_ptr(cb, COUNTED_EXIT(side_exit, getivar_undef));
+            mov(cb, REG0, imm_opnd(Qnil));
+            cmove(cb, REG1, REG0);
 
             // Push the ivar on the stack
             x86opnd_t out_opnd = ctx_stack_push(ctx, TYPE_UNKNOWN);
@@ -1488,7 +1487,8 @@ gen_get_ivar(jitstate_t *jit, ctx_t *ctx, const int max_chain_depth, VALUE compt
 
             // Check that the ivar is not Qundef
             cmp(cb, REG0, imm_opnd(Qundef));
-            je_ptr(cb, COUNTED_EXIT(side_exit, getivar_undef));
+            mov(cb, REG1, imm_opnd(Qnil));
+            cmove(cb, REG0, REG1);
 
             // Push the ivar on the stack
             x86opnd_t out_opnd = ctx_stack_push(ctx, TYPE_UNKNOWN);

--- a/yjit_iface.h
+++ b/yjit_iface.h
@@ -52,7 +52,6 @@ YJIT_DECLARE_COUNTERS(
 
     getivar_se_self_not_heap,
     getivar_idx_out_of_range,
-    getivar_undef,
     getivar_name_not_mapped,
 
     setivar_se_self_not_heap,


### PR DESCRIPTION
This case comes up relatively often in the side-exit reasons for SFR

```
getinstancevariable exit reasons:
     name_not_mapped   57698125 (85.9%)
               undef    9477738 (14.1%)
    idx_out_of_range       6597 ( 0.0%)
```