### PR TITLE
Backend labels and jumps

### DIFF
--- a/yjit_backend.h
+++ b/yjit_backend.h
@@ -17,6 +17,8 @@ enum yjit_ir_opnd_type
     EIR_VALUE,      // Immediate Ruby value, may be GC'd, movable
     EIR_INSN_OUT,   // Output of a preceding instruction in this block
     EIR_CODE_PTR,   // Pointer to a piece of code (e.g. side-exit)
+    EIR_LABEL_NAME, // A label without an index in the output
+    EIR_LABEL_IDX,  // A label that has been indexed
 
     // Low-level operands, for lowering
     EIR_MEM,        // Memory location (num_bits, base_ptr, const_offset)
@@ -65,6 +67,9 @@ typedef struct yjit_ir_opnd_t
 
         // For branch targets
         uint8_t* code_ptr;
+
+        // For strings (names, comments, etc.)
+        char* str;
     } as;
 
     // Size in bits (8, 16, 32, 64)
@@ -104,7 +109,6 @@ enum yjit_ir_op
     // Arithmetic instructions
     OP_ADD,
     OP_SUB,
-    // OP_MUL,
     OP_AND,
     OP_NOT,
 


### PR DESCRIPTION
This commit adds support for labels and jumps in the following ways:

* Adds a new instruction `OP_LABEL`, which writes the label at that point in the IR
* Adds a new operand type `EIR_LABEL_NAME`, which references a label in an instruction
* Adds 3 new jump instructions, `OP_JUMP_EQ`, `OP_JUMP_NE`, and `OP_JUMP_OVF`. The first two take two operands to compare against first, then a label operand to jump to. The last one just takes the label operand.
* When we're writing out X86, we add an additional pass through the IR that first registers all of the labels with `cb_new_label`. If there are multiple references to the same label, they are deduped by checking against the labels that have already been registers within the coddeblock object. Once they're registered, we transform them into `EIR_LABEL_IDX` operands, which represent the index in the codeblock object. Finally at the end we call `cb_link_labels` to have the X86 assembler do its thing.