### PR TITLE
Fix compilers CI

### DIFF
--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -168,8 +168,12 @@ jobs:
 
     name: ${{ matrix.entry.name }}
     runs-on: ubuntu-latest
-    container: ghcr.io/ruby/ruby-ci-image:${{ matrix.entry.container || 'clang-14' }}
+    container:
+      image: ghcr.io/ruby/ruby-ci-image:${{ matrix.entry.container || 'clang-14' }}
+      options: --user root
     steps:
+      - run: id
+        working-directory:
       - run: mkdir build
         working-directory:
       - name: setenv


### PR DESCRIPTION
From what I gathered, ruby/ruby changed the image they use for CI, and it no longer runs as root by default, and since we use the same we were impacted.

I basically just copied https://github.com/ruby/ruby/pull/4766. 