### PR TITLE
Allow to toggle YJIT stats collection from runtime

### DIFF
--- a/yjit.rb
+++ b/yjit.rb
@@ -134,6 +134,14 @@ module YJIT
     Primitive.reset_stats_bang
   end
 
+  def self.stats_enabled?
+    Primitive.cexpr! 'rb_yjit_opts.gen_stats ? Qtrue : Qfalse'
+  end
+
+  def self.stats_enabled=(enabled)
+    Primitive.set_stats_enabled(enabled)
+  end
+
   def self.enabled?
     Primitive.cexpr! 'rb_yjit_enabled_p() ? Qtrue : Qfalse'
   end

--- a/yjit_iface.c
+++ b/yjit_iface.c
@@ -797,6 +797,13 @@ reset_stats_bang(rb_execution_context_t *ec, VALUE self)
     return Qnil;
 }
 
+static VALUE
+set_stats_enabled(rb_execution_context_t *ec, VALUE self, VALUE enabled)
+{
+    rb_yjit_opts.gen_stats = RB_TEST(enabled);
+    return enabled;
+}
+
 #include "yjit.rbinc"
 
 #if YJIT_STATS


### PR DESCRIPTION
For use cases where you want to collect the metrics for a specific piece of code (typically a web request) you can have the stats turned off by default and then turn them on at runtime before executing the code you care about.

So it open possibilities like only collecting stats for X% of requests, or if a specific parameter is in the URL, etc.