### PR TITLE
Only clear the JIT function when we invalidate the entry block

### DIFF
--- a/yjit_core.c
+++ b/yjit_core.c
@@ -1114,7 +1114,14 @@ invalidate_block_version(block_t* block)
     // interpreter will run the iseq
 
 #if JIT_ENABLED
-    iseq->body->jit_func = 0;
+    // Only clear the jit_func when we're invalidating the JIT entry block.
+    // We only support compiling iseqs from index 0 right now.  So entry
+    // points will always have an instruction index of 0.  We'll need to
+    // change this in the future when we support optional parameters because
+    // they enter the function with a non-zero PC
+    if (block->blockid.idx == 0) {
+        iseq->body->jit_func = 0;
+    }
 #endif
 
     // TODO:


### PR DESCRIPTION
We should only clear the JIT function when the entry point is
invalidated.  Right now we only support compiling functions with a PC
offset of zero (functions that take optional parameters can start at
non-zero PC), so this patch just checks that the index is 0 before
clearing the jit function

[gen_entry_point will return NULL if the entry PC isn't the start of the iseq](https://github.com/shopify/yjit/blob/1bc50151b8f704a34466e47832cc181dfa7c123e/yjit_core.c#L702-L710)