### PR TITLE
Add a Ruby wrapper object for each block_t allocated

### DIFF
--- a/iseq.c
+++ b/iseq.c
@@ -323,7 +323,6 @@ rb_iseq_update_references(rb_iseq_t *iseq)
 #if USE_MJIT
         mjit_update_references(iseq);
 #endif
-        rb_yjit_iseq_update_references(body);
     }
 }
 
@@ -404,7 +403,7 @@ rb_iseq_mark(const rb_iseq_t *iseq)
 #if USE_MJIT
         mjit_mark_cc_entries(body);
 #endif
-        rb_yjit_iseq_mark(body);
+        rb_yjit_mark_iseq_entry_blocks(iseq);
     }
 
     if (FL_TEST_RAW((VALUE)iseq, ISEQ_NOT_LOADED_YET)) {

--- a/yjit.h
+++ b/yjit.h
@@ -71,11 +71,11 @@ bool rb_yjit_compile_iseq(const rb_iseq_t *iseq, rb_execution_context_t *ec);
 void rb_yjit_init(struct rb_yjit_options *options);
 void rb_yjit_bop_redefined(VALUE klass, const rb_method_entry_t *me, enum ruby_basic_operators bop);
 void rb_yjit_constant_state_changed(void);
-void rb_yjit_iseq_mark(const struct rb_iseq_constant_body *body);
 void rb_yjit_iseq_update_references(const struct rb_iseq_constant_body *body);
 void rb_yjit_iseq_free(const struct rb_iseq_constant_body *body);
 void rb_yjit_before_ractor_spawn(void);
 void yjit_constant_ic_update(const rb_iseq_t *iseq, IC ic);
 void yjit_tracing_invalidate_all(void);
+void rb_yjit_mark_iseq_entry_blocks(const rb_iseq_t *iseq);
 
 #endif // #ifndef YJIT_H

--- a/yjit.rb
+++ b/yjit.rb
@@ -1,4 +1,14 @@
 module YJIT
+  class Block
+    # call-seq: block.outgoing_ids -> list
+    #
+    # Returns a list of outgoing ids for the current block.  This list can be used
+    # in conjunction with Block#id to construct a graph of block objects.
+    def outgoing_ids
+      outgoing.map(&:id)
+    end
+  end
+
   if defined?(Disasm)
     def self.disasm(iseq, tty: $stdout && $stdout.tty?)
       iseq = RubyVM::InstructionSequence.of(iseq)

--- a/yjit_core.h
+++ b/yjit_core.h
@@ -251,6 +251,9 @@ typedef struct yjit_block_version
     // Code page this block lives on
     VALUE code_page;
 
+    // Wrapper object
+    VALUE self;
+
     // Index one past the last instruction in the iseq
     uint32_t end_idx;
 

--- a/yjit_iface.h
+++ b/yjit_iface.h
@@ -122,5 +122,6 @@ const VALUE *rb_yjit_count_side_exit_op(const VALUE *exit_pc);
 
 void yjit_unlink_method_lookup_dependency(block_t *block);
 void yjit_block_assumptions_free(block_t *block);
+VALUE yjit_wrap_block(block_t * block);
 
 #endif // #ifndef YJIT_IFACE_H


### PR DESCRIPTION
This commit adds a Ruby wrapper object for each `block_t` that is
allocated.  The wrapper object points at the `block_t`, and the
`block_t` points at it's own wrapper.

The mark function for the wrapper object will iterate through its
children (outgoing blocks) and mark the wrapper objects for those
blocks.

A new function `rb_yjit_mark_iseq_entry_blocks` is introduced that marks
only the entry blocks associated with the iseq passed in.  The entry
blocks will naturally mark their children, which will mark their
children, etc.

`block_t` wrapper objects also mark a "code page" reference, but
currently that reference is always nil.  Once we introduce code page
objects, the block wrapper objects will keep the code page objects
alive.

I gave up on doing this without `block_t` wrapper objects.  I still think it's possible, but I wanted to get something that works, then optimize later.