### PR TITLE
Implement newrange

### DIFF
--- a/test/ruby/test_yjit.rb
+++ b/test/ruby/test_yjit.rb
@@ -36,6 +36,14 @@ class TestYJIT < Test::Unit::TestCase
     assert_compiles('[1, 2, 3]', insns: %i[duparray], result: [1, 2, 3])
   end
 
+  def test_compile_newrange
+    assert_compiles('s = 1; (s..5)', insns: %i[newrange], result: 1..5)
+    assert_compiles('s = 1; e = 5; (s..e)', insns: %i[newrange], result: 1..5)
+    assert_compiles('s = 1; (s...5)', insns: %i[newrange], result: 1...5)
+    assert_compiles('s = 1; (s..)', insns: %i[newrange], result: 1..)
+    assert_compiles('e = 5; (..e)', insns: %i[newrange], result: ..5)
+  end
+
   def test_compile_opt_nil_p
     assert_compiles('nil.nil?', insns: %i[opt_nil_p], result: true)
     assert_compiles('false.nil?', insns: %i[opt_nil_p], result: false)

--- a/yjit_codegen.c
+++ b/yjit_codegen.c
@@ -916,6 +916,28 @@ gen_splatarray(jitstate_t* jit, ctx_t* ctx)
     return YJIT_KEEP_COMPILING;
 }
 
+// new range initialized from top 2 values
+static codegen_status_t
+gen_newrange(jitstate_t* jit, ctx_t* ctx)
+{
+    rb_num_t flag = (rb_num_t)jit_get_arg(jit, 0);
+
+    // rb_range_new() allocates and can raise
+    jit_prepare_routine_call(jit, ctx, REG0);
+
+    // val = rb_range_new(low, high, (int)flag);
+    mov(cb, C_ARG_REGS[0], ctx_stack_opnd(ctx, 1));
+    mov(cb, C_ARG_REGS[1], ctx_stack_opnd(ctx, 0));
+    mov(cb, C_ARG_REGS[2], imm_opnd(flag));
+    call_ptr(cb, REG0, (void *)rb_range_new);
+
+    ctx_stack_pop(ctx, 2);
+    x86opnd_t stack_ret = ctx_stack_push(ctx, TYPE_HEAP);
+    mov(cb, stack_ret, RAX);
+
+    return YJIT_KEEP_COMPILING;
+}
+
 static void
 guard_object_is_heap(codeblock_t *cb, x86opnd_t object_opnd, ctx_t *ctx, uint8_t *side_exit)
 {
@@ -4013,6 +4035,7 @@ yjit_init_codegen(void)
     yjit_reg_op(BIN(splatarray), gen_splatarray);
     yjit_reg_op(BIN(expandarray), gen_expandarray);
     yjit_reg_op(BIN(newhash), gen_newhash);
+    yjit_reg_op(BIN(newrange), gen_newrange);
     yjit_reg_op(BIN(concatstrings), gen_concatstrings);
     yjit_reg_op(BIN(putnil), gen_putnil);
     yjit_reg_op(BIN(putobject), gen_putobject);


### PR DESCRIPTION
Implements the `newrange` instructions

```
$ ./miniruby test_yjit.rb '(1+1)..'
== disasm: #<ISeq:block in <main>@(eval):1 (1,5)-(1,16)> (catch: FALSE)
0000 putobject_INT2FIX_1_                                             (   1)[LiBc]
0001 putobject_INT2FIX_1_
0002 opt_plus                               <calldata!mid:+, argc:1, ARGS_SIMPLE>[CcCr]
0004 putnil
0005 newrange                               0
0007 leave                                  [Br]

== BLOCK 1/2: 15 BYTES, ISEQ RANGE [0,4) =======================================
  ; putobject_INT2FIX_1_
  55d006dd005d:  mov    qword ptr [rbx], 3
  ; putobject_INT2FIX_1_
  55d006dd0064:  mov    qword ptr [rbx + 8], 3
== BLOCK 2/2: 123 BYTES, ISEQ RANGE [2,8) ======================================
  ; opt_plus
  55d006dd006c:  mov    rax, qword ptr [rbx]
  55d006dd006f:  sub    rax, 1
  55d006dd0073:  add    rax, qword ptr [rbx + 8]
  55d006dd0077:  jo     0x55d00edd0039
  55d006dd007d:  mov    qword ptr [rbx], rax
  ; putnil
  55d006dd0080:  mov    qword ptr [rbx + 8], 8
  ; newrange
  55d006dd0088:  movabs rax, 0x55d006b6d048
  55d006dd0092:  mov    qword ptr [r13], rax
  55d006dd0096:  lea    rbx, [rbx + 0x10]
  55d006dd009a:  mov    qword ptr [r13 + 8], rbx
  55d006dd009e:  mov    rdi, qword ptr [rbx - 0x10]
  55d006dd00a2:  mov    rsi, qword ptr [rbx - 8]
  55d006dd00a6:  movabs rdx, 0
  55d006dd00b0:  call   0x55d0050b570f
  55d006dd00b5:  mov    qword ptr [rbx - 0x10], rax
  ; leave
  55d006dd00b9:  mov    rcx, qword ptr [r13 + 0x20]
  ; check for interrupts
  ; RUBY_VM_CHECK_INTS(ec)
  55d006dd00bd:  cmp    dword ptr [r12 + 0x20], 0
  55d006dd00c3:  jne    0x55d00edd008f
  55d006dd00c9:  mov    rax, qword ptr [rbx - 0x10]
  55d006dd00cd:  add    r13, 0x40
  55d006dd00d1:  mov    qword ptr [r12 + 0x10], r13
  55d006dd00d6:  add    qword ptr [r13 + 8], 8
  55d006dd00db:  mov    rbx, qword ptr [r13 + 8]
  55d006dd00df:  mov    qword ptr [rbx - 8], rax
  55d006dd00e3:  jmp    qword ptr [r13 - 8]

Total code size: 138 bytes
```