### PR TITLE
Add codegen for rb_true and rb_false

### DIFF
--- a/yjit_codegen.c
+++ b/yjit_codegen.c
@@ -2783,6 +2783,28 @@ jit_rb_obj_not(jitstate_t *jit, ctx_t *ctx, const struct rb_callinfo *ci, const 
     return true;
 }
 
+// Codegen for rb_true()
+static bool
+jit_rb_true(jitstate_t *jit, ctx_t *ctx, const struct rb_callinfo *ci, const rb_callable_method_entry_t *cme, rb_iseq_t *block, const int32_t argc)
+{
+    ADD_COMMENT(cb, "nil? == true");
+    ctx_stack_pop(ctx, 1);
+    x86opnd_t stack_ret = ctx_stack_push(ctx, TYPE_TRUE);
+    mov(cb, stack_ret, imm_opnd(Qtrue));
+    return true;
+}
+
+// Codegen for rb_false()
+static bool
+jit_rb_false(jitstate_t *jit, ctx_t *ctx, const struct rb_callinfo *ci, const rb_callable_method_entry_t *cme, rb_iseq_t *block, const int32_t argc)
+{
+    ADD_COMMENT(cb, "nil? == false");
+    ctx_stack_pop(ctx, 1);
+    x86opnd_t stack_ret = ctx_stack_push(ctx, TYPE_FALSE);
+    mov(cb, stack_ret, imm_opnd(Qfalse));
+    return true;
+}
+
 // Check if we know how to codegen for a particular cfunc method
 static method_codegen_t
 lookup_cfunc_codegen(const rb_method_definition_t *def)
@@ -4073,4 +4095,7 @@ yjit_init_codegen(void)
     yjit_method_codegen_table = st_init_numtable();
 
     yjit_reg_method(rb_cBasicObject, "!", jit_rb_obj_not);
+
+    yjit_reg_method(rb_cNilClass, "nil?", jit_rb_true);
+    yjit_reg_method(rb_mKernel, "nil?", jit_rb_false);
 }


### PR DESCRIPTION
These are used by `.nil?` and therefore `opt_nil_p`.

For `nil.nil?` we generate:

```
== disasm: #<ISeq:block in <main>@(eval):1 (1,5)-(1,17)> (catch: FALSE)
0000 putnil                                                           (   1)[LiBc]
0001 opt_nil_p                              <calldata!mid:nil?, argc:0, ARGS_SIMPLE>[CcCr]
0003 leave                                  [Br]

== BLOCK 1/3: 7 BYTES, ISEQ RANGE [0,3) ========================================
  ; putnil
  55ba551d105d:  mov    qword ptr [rbx], 8
== BLOCK 2/3: 10 BYTES, ISEQ RANGE [1,3) =======================================
  ; opt_nil_p
  55ba551d1064:  mov    rax, qword ptr [rbx]
  ; nil? == true
  55ba551d1067:  mov    qword ptr [rbx], 0x14
```