### PR TITLE
Stamp out some out of memory crashes 

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -1928,3 +1928,44 @@ assert_equal '42', %q{
 
   ractor.take
 }
+
+# Test generating new code while out of memory
+assert_equal 'ok', %q{
+  def foo
+    :ok
+  end
+
+  YJIT.simulate_out_of_mem!
+  foo
+  foo
+}
+
+# Test hitting lazy branch stub while out of memory
+assert_equal 'ok', %q{
+  def compiled(foo)
+    if foo
+      itself
+      :ng
+    else
+      itself
+      :ok
+    end
+  end
+
+  compiled(true)
+  YJIT.simulate_out_of_mem!
+  compiled(false)
+}
+
+assert_equal 'ok', %q{
+  def bar(yjit)
+    yjit.simulate_out_of_mem!
+  end
+
+  def foo(yjit)
+    bar(yjit)
+    :ok
+  end
+
+  foo(YJIT)
+}

--- a/yjit.rb
+++ b/yjit.rb
@@ -146,6 +146,12 @@ module YJIT
     Primitive.cexpr! 'rb_yjit_enabled_p() ? Qtrue : Qfalse'
   end
 
+  # Method for testing when YJIT runs out of executable memory
+  def self.simulate_out_of_mem!
+    # defined in yjit_iface.c
+    Primitive.simulate_out_of_mem_bang
+  end
+
   class << self
     private
 

--- a/yjit_codegen.h
+++ b/yjit_codegen.h
@@ -48,7 +48,9 @@ typedef codegen_status_t (*codegen_fn)(jitstate_t* jit, ctx_t* ctx);
 
 uint8_t* yjit_entry_prologue(const rb_iseq_t* iseq);
 
-void yjit_gen_block(block_t* block, rb_execution_context_t* ec);
+bool yjit_gen_block(block_t *block, rb_execution_context_t *ec);
+
+uint32_t yjit_gen_stub_compile_failure_exit(VALUE *exit_pc, const ctx_t *ctx, codeblock_t *cb);
 
 void yjit_init_codegen(void);
 

--- a/yjit_core.h
+++ b/yjit_core.h
@@ -265,7 +265,7 @@ typedef struct yjit_block_version
 } block_t;
 
 // Context object methods
-x86opnd_t ctx_sp_opnd(ctx_t* ctx, int32_t offset_bytes);
+x86opnd_t ctx_sp_opnd(const ctx_t *ctx, int32_t offset_bytes);
 x86opnd_t ctx_stack_push_mapping(ctx_t* ctx, temp_type_mapping_t mapping);
 x86opnd_t ctx_stack_push(ctx_t* ctx, val_type_t type);
 x86opnd_t ctx_stack_push_self(ctx_t* ctx);
@@ -285,7 +285,6 @@ temp_type_mapping_t ctx_get_opnd_mapping(const ctx_t* ctx, insn_opnd_t opnd);
 void ctx_set_opnd_mapping(ctx_t* ctx, insn_opnd_t opnd, temp_type_mapping_t type_mapping);
 
 block_t* find_block_version(blockid_t blockid, const ctx_t* ctx);
-block_t* gen_block_version(blockid_t blockid, const ctx_t* ctx, rb_execution_context_t *ec);
 uint8_t*  gen_entry_point(const rb_iseq_t *iseq, uint32_t insn_idx, rb_execution_context_t *ec);
 void yjit_free_block(block_t *block);
 rb_yjit_block_array_t yjit_get_version_array(const rb_iseq_t *iseq, unsigned idx);

--- a/yjit_iface.c
+++ b/yjit_iface.c
@@ -822,8 +822,10 @@ set_stats_enabled(rb_execution_context_t *ec, VALUE self, VALUE enabled)
 static VALUE
 simulate_out_of_mem_bang(rb_execution_context_t *ec, VALUE self)
 {
-    cb_set_pos(cb, cb->mem_size - 1);
-    cb_set_pos(ocb, ocb->mem_size - 1);
+    if (cb && ocb) {
+        cb_set_pos(cb, cb->mem_size - 1);
+        cb_set_pos(ocb, ocb->mem_size - 1);
+    }
     return Qnil;
 }
 

--- a/yjit_iface.c
+++ b/yjit_iface.c
@@ -818,6 +818,15 @@ set_stats_enabled(rb_execution_context_t *ec, VALUE self, VALUE enabled)
     return enabled;
 }
 
+// Primitive in yjit.rb for testing running out of executable memory
+static VALUE
+simulate_out_of_mem_bang(rb_execution_context_t *ec, VALUE self)
+{
+    cb_set_pos(cb, cb->mem_size - 1);
+    cb_set_pos(ocb, ocb->mem_size - 1);
+    return Qnil;
+}
+
 #include "yjit.rbinc"
 
 #if YJIT_STATS

--- a/yjit_iface.h
+++ b/yjit_iface.h
@@ -89,6 +89,8 @@ YJIT_DECLARE_COUNTERS(
     binding_allocations,
     binding_set,
 
+    exit_stub_compile_failure,
+
     vm_insns_count,
     compiled_iseq_count,
 


### PR DESCRIPTION
This change makes it so that we don't crash with rb_bug() when we run
out of executable memory while generating code for a new entry point
or when hitting a lazy stub.

A new API, `YJIT.simulate_out_of_mem!`, is used to test for out of
memory conditions.

If we run out while generating a new entry point, we can handle it by
not installing an entry point. Handling running out while compiling a
lazy stub is more involved.

An exit for the stub target is added to the the piece of code that calls
branch_stub_hit() and used when branch_stub_hit() returns NULL. Unlike
before, being able to generate new code is no longer required for
lazy stubs to function correctly.

A situation not handled by this change is when we need to invalidate a
block while we are out of memory. We generate new stubs when we
invalidate and that is not handled for now.