### PR TITLE
Allow special case of expandarray with nil

### DIFF
--- a/test/ruby/test_yjit.rb
+++ b/test/ruby/test_yjit.rb
@@ -136,6 +136,19 @@ class TestYJIT < Test::Unit::TestCase
     RUBY
   end
 
+  def test_expandarray
+    assert_compiles(<<~'RUBY', insns: %i[expandarray], result: [1, 2])
+      a, b = [1, 2]
+    RUBY
+  end
+
+  def test_expandarray_nil
+    assert_compiles(<<~'RUBY', insns: %i[expandarray], result: [nil, nil])
+      a, b = nil
+      [a, b]
+    RUBY
+  end
+
   def test_compile_opt_getinlinecache
     assert_compiles(<<~RUBY, insns: %i[opt_getinlinecache], result: 123, min_calls: 2)
       def get_foo

--- a/yjit_codegen.c
+++ b/yjit_codegen.c
@@ -986,7 +986,18 @@ gen_expandarray(jitstate_t* jit, ctx_t* ctx)
     // num is the number of requested values. If there aren't enough in the
     // array then we're going to push on nils.
     rb_num_t num = (rb_num_t) jit_get_arg(jit, 0);
+    val_type_t array_type = ctx_get_opnd_type(ctx, OPND_STACK(0));
     x86opnd_t array_opnd = ctx_stack_pop(ctx, 1);
+
+    if (array_type.type == ETYPE_NIL) {
+        // special case for a, b = nil pattern
+        // push N nils onto the stack
+        for (int i = 0; i < num; i++) {
+            x86opnd_t push = ctx_stack_push(ctx, TYPE_NIL);
+            mov(cb, push, imm_opnd(Qnil));
+        }
+        return YJIT_KEEP_COMPILING;
+    }
 
     // Move the array from the stack into REG0 and check that it's an array.
     mov(cb, REG0, array_opnd);


### PR DESCRIPTION
This adds support for expandarray being passed an explicit `nil`. I'm really don't like this pattern but ragel seems to generate it.

For example
```
a, b, c = nil
```
to set `a`, `b`, and `c` to nil. (🤮 I would prefer `a = b = c = nil`)

Fortunately, it's at least easy to implement by checking for a known nil type and pushing N `nil`s onto the stack.

It's likely we could support this case for other non-array values being passed, but I'm not sure how common that is.

Found in the ragel generated mail parsers in https://github.com/Shopify/yjit-bench/pull/40