### PR TITLE
Count interpreter instructions when -DYJIT_STATS=1

### DIFF
--- a/vm.c
+++ b/vm.c
@@ -28,6 +28,7 @@
 #include "internal/sanitizers.h"
 #include "iseq.h"
 #include "mjit.h"
+#include "yjit.h"
 #include "ruby/st.h"
 #include "ruby/vm.h"
 #include "vm_core.h"
@@ -37,7 +38,6 @@
 #include "vm_insnhelper.h"
 #include "ractor_core.h"
 #include "vm_sync.h"
-#include "yjit.h"
 
 #include "builtin.h"
 
@@ -343,10 +343,6 @@ vm_bind_update_env(VALUE bindval, rb_binding_t *bind, VALUE envval)
 static void vm_collect_usage_operand(int insn, int n, VALUE op);
 static void vm_collect_usage_insn(int insn);
 static void vm_collect_usage_register(int reg, int isset);
-#endif
-
-#if RUBY_DEBUG
-static void vm_yjit_collect_usage_insn(int insn);
 #endif
 
 static VALUE vm_make_env_object(const rb_execution_context_t *ec, rb_control_frame_t *cfp);
@@ -4059,14 +4055,6 @@ MAYBE_UNUSED(static void (*ruby_vm_collect_usage_func_insn)(int insn)) = 0;
 MAYBE_UNUSED(static void (*ruby_vm_collect_usage_func_operand)(int insn, int n, VALUE op)) = 0;
 MAYBE_UNUSED(static void (*ruby_vm_collect_usage_func_register)(int reg, int isset)) = 0;
 
-#endif
-
-#if RUBY_DEBUG
-static void
-vm_yjit_collect_usage_insn(int insn)
-{
-    rb_yjit_collect_vm_usage_insn(insn);
-}
 #endif
 
 #if VM_COLLECT_USAGE_DETAILS

--- a/vm_insnhelper.h
+++ b/vm_insnhelper.h
@@ -25,9 +25,9 @@ MJIT_SYMBOL_EXPORT_END
 #define COLLECT_USAGE_OPERAND(insn, n, op) vm_collect_usage_operand((insn), (n), ((VALUE)(op)))
 
 #define COLLECT_USAGE_REGISTER(reg, s)     vm_collect_usage_register((reg), (s))
-#elif RUBY_DEBUG
+#elif YJIT_STATS
 /* for --yjit-stats */
-#define COLLECT_USAGE_INSN(insn)           vm_yjit_collect_usage_insn(insn)
+#define COLLECT_USAGE_INSN(insn)           rb_yjit_collect_vm_usage_insn(insn)
 #define COLLECT_USAGE_OPERAND(insn, n, op)	/* none */
 #define COLLECT_USAGE_REGISTER(reg, s)		/* none */
 #else

--- a/yjit.h
+++ b/yjit.h
@@ -5,6 +5,8 @@
 #ifndef YJIT_H
 #define YJIT_H 1
 
+#include "ruby/internal/config.h"
+#include "ruby_assert.h" // for RUBY_DEBUG
 #include "vm_core.h"
 #include "method.h"
 
@@ -25,6 +27,10 @@
 #ifndef YJIT_DUMP_MODE
 #define YJIT_DUMP_MODE 0
 #endif
+
+#ifndef YJIT_STATS
+# define YJIT_STATS RUBY_DEBUG
+#endif // ifndef YJIT_STATS
 
 #ifndef rb_iseq_t
 typedef struct rb_iseq_struct rb_iseq_t;


### PR DESCRIPTION
The interpreter instruction count was enabled based on RUBY_DEBUG as
opposed to YJIT_STATS. In builds with YJIT_STATS=1 but RUBY_DEBUG=0,
the count was not available.

Move YJIT_STATS in yjit.h where declarations are expoed to code outside
of YJIT. Also reduce the changes made to the interpreter for calling
into YJIT's instruction counting function.