### PR TITLE
Call instructions for the new backend

### DIFF
--- a/yjit_backend.h
+++ b/yjit_backend.h
@@ -132,8 +132,8 @@ enum yjit_ir_op
     OP_JUMP_NE,
     OP_JUMP_OVF,
 
-    // TODO:
-    //CALL_CFUNC (var-arg...)
+    OP_CALL,
+    OP_CCALL,
     OP_RET,
     OP_RETVAL,
 


### PR DESCRIPTION
This adds OP_CALL and OP_CCALL. OP_CALL is just a wrapper around the x86 call instruction, and accepts as its only operand a pointer to the function that should be called. OP_CCALL is a higher-level instruction that accepts a variable number of arguments that should be passed to the function. When allocating registers, OP_CCALL breaks down to a mov and an OP_CALL. OP_CALL is responsible for putting values into the correct registers in order to handle argument order correctly since that's platform-specific.

There's definitely still work to be done here with correctly setting argument registers and pushing/popping callee-save registers so that we don't shoot ourselves in the foot, but this is working so I figured I'd push it.