### PR TITLE
Skip opt_case_dispatch

### DIFF
--- a/yjit_codegen.c
+++ b/yjit_codegen.c
@@ -2520,6 +2520,22 @@ gen_opt_regexpmatch2(jitstate_t *jit, ctx_t *ctx)
     return gen_opt_send_without_block(jit, ctx);
 }
 
+static codegen_status_t
+gen_opt_case_dispatch(jitstate_t* jit, ctx_t* ctx)
+{
+    // Normally this instruction would lookup the key in a hash and jump to an
+    // offset based on that.
+    // Instead we can take the fallback case and continue with the next
+    // instruciton.
+    // We'd hope that our jitted code will be sufficiently fast without the
+    // hash lookup, at least for small hashes, but it's worth revisiting this
+    // assumption in the future.
+
+    ctx_stack_pop(ctx, 1);
+
+    return YJIT_KEEP_COMPILING; // continue with the next instruction
+}
+
 void
 gen_branchif_branch(codeblock_t* cb, uint8_t* target0, uint8_t* target1, uint8_t shape)
 {
@@ -4211,6 +4227,7 @@ yjit_init_codegen(void)
     yjit_reg_op(BIN(opt_getinlinecache), gen_opt_getinlinecache);
     yjit_reg_op(BIN(opt_invokebuiltin_delegate), gen_opt_invokebuiltin_delegate);
     yjit_reg_op(BIN(opt_invokebuiltin_delegate_leave), gen_opt_invokebuiltin_delegate);
+    yjit_reg_op(BIN(opt_case_dispatch), gen_opt_case_dispatch);
     yjit_reg_op(BIN(branchif), gen_branchif);
     yjit_reg_op(BIN(branchunless), gen_branchunless);
     yjit_reg_op(BIN(branchnil), gen_branchnil);


### PR DESCRIPTION
Normally this instruction does a lookup in a hash table to determine the index to jump to. I think eventually it would be nice to compile this into a jump table, but for now I think it would be faster to use the fallback case rather than side-exiting (especially as this table is often small, and for the cases that it's large the side exit really hurts our coverage).