### PR TITLE
Fix opt_eq for overridden equality

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -1943,7 +1943,7 @@ assert_equal '[true, false, false, false]', %q{
   ]
 }
 
-# Redefined eq
+# Redefined String eq
 assert_equal 'true', %q{
   class String
     def ==(other)
@@ -1951,6 +1951,26 @@ assert_equal 'true', %q{
     end
   end
 
-  "foo" == "bar"
-  "foo" == "bar"
+  def eq(a, b)
+    a == b
+  end
+
+  eq("foo", "bar")
+  eq("foo", "bar")
+}
+
+# Redefined Integer eq
+assert_equal 'true', %q{
+  class Integer
+    def ==(other)
+      true
+    end
+  end
+
+  def eq(a, b)
+    a == b
+  end
+
+  eq(1, 2)
+  eq(1, 2)
 }

--- a/yjit_codegen.c
+++ b/yjit_codegen.c
@@ -2019,7 +2019,8 @@ gen_equality_specialized(jitstate_t* jit, ctx_t* ctx, uint8_t *side_exit)
 
     if (FIXNUM_P(comptime_a) && FIXNUM_P(comptime_b)) {
         if (!assume_bop_not_redefined(jit->block, INTEGER_REDEFINED_OP_FLAG, BOP_EQ)) {
-            return YJIT_CANT_COMPILE;
+            // if overridden, emit the generic version
+            return false;
         }
 
         guard_two_fixnums(ctx, side_exit);
@@ -2038,9 +2039,10 @@ gen_equality_specialized(jitstate_t* jit, ctx_t* ctx, uint8_t *side_exit)
 
         return true;
     } else if (CLASS_OF(comptime_a) == rb_cString &&
-		    CLASS_OF(comptime_b) == rb_cString) {
+            CLASS_OF(comptime_b) == rb_cString) {
         if (!assume_bop_not_redefined(jit->block, STRING_REDEFINED_OP_FLAG, BOP_EQ)) {
-            return YJIT_CANT_COMPILE;
+            // if overridden, emit the generic version
+            return false;
         }
 
         // Load a and b in preparation for call later


### PR DESCRIPTION
Previously `gen_equality_specialized` was incorrectly returning `YJIT_CANT_COMPILE` when an op was overridden. It should have been returning a boolean. Oops 😓

Additionally the bootstraptest for this didn't work because the equality was at the top level, where it couldn't get compiled, rather than in a method.