### PR TITLE
Fix warnings about redefining YJIT_STATS

### DIFF
--- a/yjit_codegen.c
+++ b/yjit_codegen.c
@@ -203,8 +203,7 @@ record_global_inval_patch(const codeblock_t *cb, uint32_t outline_block_target_p
 
 static bool jit_guard_known_klass(jitstate_t *jit, ctx_t* ctx, VALUE known_klass, insn_opnd_t insn_opnd, VALUE sample_instance, const int max_chain_depth, uint8_t *side_exit);
 
-#if RUBY_DEBUG
-# define YJIT_STATS 1
+#if YJIT_STATS
 
 // Add a comment at the current position in the code block
 static void
@@ -290,14 +289,11 @@ verify_ctx(jitstate_t *jit, ctx_t *ctx)
 }
 
 #else
-#ifndef YJIT_STATS
-#define YJIT_STATS 0
-#endif // ifndef YJIT_STATS
 
 #define ADD_COMMENT(cb, comment) ((void)0)
 #define verify_ctx(jit, ctx) ((void)0)
 
-#endif // if RUBY_DEBUG
+#endif // if YJIT_STATS
 
 #if YJIT_STATS
 

--- a/yjit_iface.c
+++ b/yjit_iface.c
@@ -24,13 +24,8 @@ static VALUE cYjitDisasmInsn;
 static VALUE mYjit;
 static VALUE cYjitBlock;
 
-#if RUBY_DEBUG
-# define YJIT_STATS 1
+#if YJIT_STATS
 static VALUE cYjitCodeComment;
-#else
-# ifndef YJIT_STATS
-#  define YJIT_STATS 0
-# endif
 #endif
 
 #if YJIT_STATS

--- a/yjit_iface.h
+++ b/yjit_iface.h
@@ -6,8 +6,9 @@
 #ifndef YJIT_IFACE_H
 #define YJIT_IFACE_H 1
 
-#include "ruby/ruby.h"
-#include "ruby/assert.h" // for RUBY_DEBUG
+#include "ruby/internal/config.h"
+#include "ruby_assert.h" // for RUBY_DEBUG
+#include "yjit.h" // for YJIT_STATS
 #include "vm_core.h"
 #include "yjit_core.h"
 
@@ -15,8 +16,7 @@
 # define YJIT_DEFAULT_CALL_THRESHOLD 10
 #endif
 
-#if RUBY_DEBUG
-# define YJIT_STATS 1
+#if YJIT_STATS
 struct yjit_comment {
     uint32_t offset;
     const char *comment;
@@ -25,11 +25,7 @@ struct yjit_comment {
 typedef rb_darray(struct yjit_comment) yjit_comment_array_t;
 
 extern yjit_comment_array_t yjit_code_comments;
-#else
-# ifndef YJIT_STATS
-#  define YJIT_STATS 0
-# endif // ifndef YJIT_STATS
-#endif // if RUBY_DEBUG
+#endif // if YJIT_STATS
 
 
 #if YJIT_STATS


### PR DESCRIPTION
Follow up for ecb5b383a0c17550b9b27663005049ddac871edb. Now that
YJIT_STATS is defined in yjit.h, it shoudl be the only place that
defines it.