### PR TITLE
Fix opt_aset comptime_key check

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -1996,3 +1996,13 @@ assert_equal 'true', %q{
   eq(1, 2)
   eq(1, 2)
 }
+
+# aset on array with invalid key
+assert_normal_exit %q{
+  def foo(arr)
+    arr[:foo] = 123
+  end
+
+  foo([1]) rescue nil
+  foo([1]) rescue nil
+}

--- a/yjit_codegen.c
+++ b/yjit_codegen.c
@@ -2186,14 +2186,13 @@ gen_opt_aset(jitstate_t *jit, ctx_t *ctx)
 
     VALUE comptime_recv = jit_peek_at_stack(jit, ctx, 2);
     VALUE comptime_key  = jit_peek_at_stack(jit, ctx, 1);
-    VALUE comptime_val  = jit_peek_at_stack(jit, ctx, 0);
 
     // Get the operands from the stack
     x86opnd_t recv = ctx_stack_opnd(ctx, 2);
     x86opnd_t key = ctx_stack_opnd(ctx, 1);
     x86opnd_t val = ctx_stack_opnd(ctx, 0);
 
-    if (CLASS_OF(comptime_recv) == rb_cArray && FIXNUM_P(comptime_val)) {
+    if (CLASS_OF(comptime_recv) == rb_cArray && FIXNUM_P(comptime_key)) {
         uint8_t* side_exit = yjit_side_exit(jit, ctx);
 
         // Guard receiver is an Array


### PR DESCRIPTION
This had a typo where it was checking `val` instead of `key` 🤦‍♂️

Adds a test which previously had an assertion fail in `jit_guard_known_klass`