### PR TITLE
Add jit_obj_info_dump debugging method

### DIFF
--- a/yjit_codegen.c
+++ b/yjit_codegen.c
@@ -70,6 +70,16 @@ jit_print_loc(jitstate_t* jit, const char* msg)
     fprintf(stderr, "%s %.*s:%u\n", msg, (int)len, ptr, rb_iseq_line_no(jit->iseq, jit->insn_idx));
 }
 
+// dump an object for debugging purposes
+RBIMPL_ATTR_MAYBE_UNUSED()
+static void
+jit_obj_info_dump(codeblock_t *cb, x86opnd_t opnd) {
+    push_regs(cb);
+    mov(cb, C_ARG_REGS[0], opnd);
+    call_ptr(cb, REG0, (void *)rb_obj_info_dump);
+    pop_regs(cb);
+}
+
 // Get the current instruction's opcode
 static int
 jit_get_opcode(jitstate_t* jit)


### PR DESCRIPTION
This adds `jit_obj_info_dump` which generates runtime code to call `rb_obj_info_dump` on the provided operand. This should provide friendlier debugging output than `print_ptr` when inspecting a Ruby VALUE.

`rb_obj_info_dump` shouldn't allocate (it can be used in GC debugging) so this should be safe to call wherever.