### PR TITLE
Step 2 to remove the global cb/ocb objects.

### DIFF
--- a/yjit_codegen.h
+++ b/yjit_codegen.h
@@ -9,37 +9,6 @@ extern codeblock_t *cb;
 extern codeblock_t *ocb;
 extern uint32_t yjit_codepage_frozen_bytes;
 
-// Code generation state
-typedef struct JITState
-{
-    // Block version being compiled
-    block_t *block;
-
-    // Instruction sequence this is associated with
-    const rb_iseq_t *iseq;
-
-    // Index of the current instruction being compiled
-    uint32_t insn_idx;
-
-    // Opcode for the instruction being compiled
-    int opcode;
-
-    // PC of the instruction being compiled
-    VALUE *pc;
-
-    // Side exit to the instruction being compiled. See :side-exit:.
-    uint8_t *side_exit_for_pc;
-
-    // Execution context when compilation started
-    // This allows us to peek at run-time values
-    rb_execution_context_t *ec;
-
-    // Whether we need to record the code address at
-    // the end of this bytecode instruction for global invalidation
-    bool record_boundary_patch_point;
-
-} jitstate_t;
-
 typedef enum codegen_status {
     YJIT_END_BLOCK,
     YJIT_KEEP_COMPILING,

--- a/yjit_core.c
+++ b/yjit_core.c
@@ -872,7 +872,7 @@ uint8_t* get_branch_target(
 }
 
 void gen_branch(
-    block_t* block,
+    jitstate_t* jit,
     const ctx_t* src_ctx,
     blockid_t target0,
     const ctx_t* ctx0,
@@ -883,7 +883,7 @@ void gen_branch(
 {
     RUBY_ASSERT(target0.iseq != NULL);
 
-    branch_t* branch = make_branch_entry(block, src_ctx, gen_fn);
+    branch_t* branch = make_branch_entry(jit->block, src_ctx, gen_fn);
     branch->targets[0] = target0;
     branch->targets[1] = target1;
     branch->target_ctxs[0] = *ctx0;
@@ -918,14 +918,14 @@ gen_jump_branch(codeblock_t* cb, uint8_t* target0, uint8_t* target1, uint8_t sha
 }
 
 void gen_direct_jump(
-    block_t* block,
+    jitstate_t* jit,
     const ctx_t* ctx,
     blockid_t target0
 )
 {
     RUBY_ASSERT(target0.iseq != NULL);
 
-    branch_t* branch = make_branch_entry(block, ctx, gen_jump_branch);
+    branch_t* branch = make_branch_entry(jit->block, ctx, gen_jump_branch);
     branch->targets[0] = target0;
     branch->target_ctxs[0] = *ctx;
 
@@ -956,8 +956,7 @@ void gen_direct_jump(
 
 // Create a stub to force the code up to this point to be executed
 void defer_compilation(
-    block_t* block,
-    uint32_t insn_idx,
+    jitstate_t* jit,
     ctx_t* cur_ctx
 )
 {
@@ -975,14 +974,15 @@ void defer_compilation(
 
     next_ctx.chain_depth += 1;
 
-    branch_t* branch = make_branch_entry(block, cur_ctx, gen_jump_branch);
+    branch_t* branch = make_branch_entry(jit->block, cur_ctx, gen_jump_branch);
 
     // Get the branch targets or stubs
     branch->target_ctxs[0] = next_ctx;
-    branch->targets[0] = (blockid_t){ block->blockid.iseq, insn_idx };
+    branch->targets[0] = (blockid_t){ jit->block->blockid.iseq, jit->insn_idx };
     branch->dst_addrs[0] = get_branch_target(branch->targets[0], &next_ctx, branch, 0);
 
     // Call the branch generation function
+    codeblock_t* cb = jit->cb;
     branch->start_pos = cb->write_pos;
     gen_jump_branch(cb, branch->dst_addrs[0], NULL, SHAPE_DEFAULT);
     branch->end_pos = cb->write_pos;

--- a/yjit_core.h
+++ b/yjit_core.h
@@ -264,6 +264,42 @@ typedef struct yjit_block_version
 
 } block_t;
 
+// Code generation state
+typedef struct JITState
+{
+    // Inline and outlined code blocks we are
+    // currently generating code into
+    codeblock_t* cb;
+    codeblock_t* ocb;
+
+    // Block version being compiled
+    block_t *block;
+
+    // Instruction sequence this is associated with
+    const rb_iseq_t *iseq;
+
+    // Index of the current instruction being compiled
+    uint32_t insn_idx;
+
+    // Opcode for the instruction being compiled
+    int opcode;
+
+    // PC of the instruction being compiled
+    VALUE *pc;
+
+    // Side exit to the instruction being compiled. See :side-exit:.
+    uint8_t *side_exit_for_pc;
+
+    // Execution context when compilation started
+    // This allows us to peek at run-time values
+    rb_execution_context_t *ec;
+
+    // Whether we need to record the code address at
+    // the end of this bytecode instruction for global invalidation
+    bool record_boundary_patch_point;
+
+} jitstate_t;
+
 // Context object methods
 x86opnd_t ctx_sp_opnd(ctx_t* ctx, int32_t offset_bytes);
 x86opnd_t ctx_stack_push_mapping(ctx_t* ctx, temp_type_mapping_t mapping);
@@ -291,7 +327,7 @@ void yjit_free_block(block_t *block);
 rb_yjit_block_array_t yjit_get_version_array(const rb_iseq_t *iseq, unsigned idx);
 
 void gen_branch(
-    block_t* block,
+    jitstate_t* jit,
     const ctx_t* src_ctx,
     blockid_t target0,
     const ctx_t* ctx0,
@@ -301,14 +337,13 @@ void gen_branch(
 );
 
 void gen_direct_jump(
-    block_t* block,
+    jitstate_t* jit,
     const ctx_t* ctx,
     blockid_t target0
 );
 
 void defer_compilation(
-    block_t* block,
-    uint32_t insn_idx,
+    jitstate_t* jit,
     ctx_t* cur_ctx
 );
 


### PR DESCRIPTION
Pass jitstate_t around to yjit_core methods that will need the cb/ocb.