### PR TITLE
Add counters for version invalidation reasons

### DIFF
--- a/yjit.rb
+++ b/yjit.rb
@@ -160,6 +160,7 @@ module YJIT
       print_counters(stats, prefix: 'oaref_', prompt: 'opt_aref exit reasons: ')
       print_counters(stats, prefix: 'expandarray_', prompt: 'expandarray exit reasons: ')
       print_counters(stats, prefix: 'opt_getinlinecache_', prompt: 'opt_getinlinecache exit reasons: ')
+      print_counters(stats, prefix: 'invalidate_', prompt: 'invalidation reasons: ')
 
       side_exits = total_exit_count(stats)
       total_exits = side_exits + stats[:leave_interp_return]

--- a/yjit_codegen.c
+++ b/yjit_codegen.c
@@ -4056,7 +4056,7 @@ gen_opt_getinlinecache(jitstate_t* jit, ctx_t* ctx, codeblock_t* cb)
         // Cache is keyed on a certain lexical scope. Use the interpreter's cache.
         uint8_t *side_exit = yjit_side_exit(jit, ctx);
 
-        // Call function to verify the cache
+        // Call function to verify the cache. It doesn't allocate or call methods.
         bool rb_vm_ic_hit_p(IC ic, const VALUE *reg_ep);
         mov(cb, C_ARG_REGS[0], const_ptr_opnd((void *)ic));
         mov(cb, C_ARG_REGS[1], member_opnd(REG_CFP, rb_control_frame_t, ep));

--- a/yjit_iface.h
+++ b/yjit_iface.h
@@ -90,7 +90,14 @@ YJIT_DECLARE_COUNTERS(
     vm_insns_count,
     compiled_iseq_count,
     compiled_block_count,
+
     invalidation_count,
+    invalidate_method_lookup,
+    invalidate_bop_redefined,
+    invalidate_ractor_spawn,
+    invalidate_constant_state_bump,
+    invalidate_constant_ic_fill,
+
     constant_state_bumps,
 
     expandarray_splat,


### PR DESCRIPTION
I noticed that there were two st_table iterators that do exactly the
same thing so I merged them into one. The new iterators does the
counting and expects the caller to pass in the reason.