### PR TITLE
Add specialization for String#to_s on plain strings

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -2038,3 +2038,38 @@ assert_equal '42',  %q{
 
   Ractor.new { A.foo }.take
 }
+
+assert_equal '["plain", "special", "sub", "plain"]', %q{
+  def foo(arg)
+    arg.to_s
+  end
+
+  class Sub < String
+  end
+
+  special = String.new("special")
+  special.singleton_class
+
+  [
+    foo("plain"),
+    foo(special),
+    foo(Sub.new("sub")),
+    foo("plain")
+  ]
+}
+
+assert_equal '["sub", "sub"]', %q{
+  def foo(arg)
+    arg.to_s
+  end
+
+  class Sub < String
+    def to_s
+      super
+    end
+  end
+
+  sub = Sub.new("sub")
+
+  [foo(sub), foo(sub)]
+}

--- a/yjit_codegen.c
+++ b/yjit_codegen.c
@@ -2953,9 +2953,31 @@ jit_protected_callee_ancestry_guard(jitstate_t *jit, codeblock_t *cb, const rb_c
 }
 
 // Return true when the codegen function generates code.
-// known_recv_klass is non-NULL when the caller has used jit_guard_known_klass
-// See yjit_reg_method.
+// known_recv_klass is non-NULL when the caller has used jit_guard_known_klass().
+// See yjit_reg_method().
 typedef bool (*method_codegen_t)(jitstate_t *jit, ctx_t *ctx, const struct rb_callinfo *ci, const rb_callable_method_entry_t *cme, rb_iseq_t *block, const int32_t argc, VALUE *known_recv_klass);
+
+// Register a specialized codegen function for a particular method. Note that
+// the if the function returns true, the code it generates runs without a
+// control frame and without interrupt checks. To avoid creating observable
+// behavior changes, the codegen function should only target simple code paths
+// that do not allocate and do not make method calls.
+static void
+yjit_reg_method(VALUE klass, const char *mid_str, method_codegen_t gen_fn)
+{
+    ID mid = rb_intern(mid_str);
+    const rb_method_entry_t *me = rb_method_entry_at(klass, mid);
+
+    if (!me) {
+        rb_bug("undefined optimized method: %s", rb_id2name(mid));
+    }
+
+    // For now, only cfuncs are supported
+    RUBY_ASSERT(me && me->def);
+    RUBY_ASSERT(me->def->type == VM_METHOD_TYPE_CFUNC);
+
+    st_insert(yjit_method_codegen_table, (st_data_t)me->def->method_serial, (st_data_t)gen_fn);
+}
 
 // Codegen for rb_obj_not().
 // Note, caller is responsible for generating all the right guards, including
@@ -3030,9 +3052,9 @@ jit_rb_obj_equal(jitstate_t *jit, ctx_t *ctx, const struct rb_callinfo *ci, cons
 }
 
 // Codegen for rb_str_to_s()
-// When String#to_s is called on a String instance, the method returns self and most
-// of the overhead comes from setting up the method call. We observed that this situation
-// happens a lot in some workloads.
+// When String#to_s is called on a String instance, the method returns self and
+// most of the overhead comes from setting up the method call. We observed that
+// this situation happens a lot in some workloads.
 static bool
 jit_rb_str_to_s(jitstate_t *jit, ctx_t *ctx, const struct rb_callinfo *ci, const rb_callable_method_entry_t *cme, rb_iseq_t *block, const int32_t argc, VALUE *recv_known_klass)
 {
@@ -4362,23 +4384,6 @@ invalidate_all_blocks_for_tracing(const rb_iseq_t *iseq)
 }
 
 static void
-yjit_reg_method(VALUE klass, const char *mid_str, method_codegen_t gen_fn)
-{
-    ID mid = rb_intern(mid_str);
-    const rb_method_entry_t *me = rb_method_entry_at(klass, mid);
-
-    if (!me) {
-        rb_bug("undefined optimized method: %s", rb_id2name(mid));
-    }
-
-    // For now, only cfuncs are supported
-    VM_ASSERT(me && me->def);
-    VM_ASSERT(me->def->type == VM_METHOD_TYPE_CFUNC);
-
-    st_insert(yjit_method_codegen_table, (st_data_t)me->def->method_serial, (st_data_t)gen_fn);
-}
-
-static void
 yjit_reg_op(int opcode, codegen_fn gen_fn)
 {
     RUBY_ASSERT(opcode >= 0 && opcode < VM_INSTRUCTION_SIZE);
@@ -4486,6 +4491,7 @@ yjit_init_codegen(void)
 
     yjit_method_codegen_table = st_init_numtable();
 
+    // Specialization for C methods. See yjit_reg_method() for details.
     yjit_reg_method(rb_cBasicObject, "!", jit_rb_obj_not);
 
     yjit_reg_method(rb_cNilClass, "nil?", jit_rb_true);

--- a/yjit_codegen.c
+++ b/yjit_codegen.c
@@ -2953,13 +2953,15 @@ jit_protected_callee_ancestry_guard(jitstate_t *jit, codeblock_t *cb, const rb_c
 }
 
 // Return true when the codegen function generates code.
-typedef bool (*method_codegen_t)(jitstate_t *jit, ctx_t *ctx, const struct rb_callinfo *ci, const rb_callable_method_entry_t *cme, rb_iseq_t *block, const int32_t argc);
+// known_recv_klass is non-NULL when the caller has used jit_guard_known_klass
+// See yjit_reg_method.
+typedef bool (*method_codegen_t)(jitstate_t *jit, ctx_t *ctx, const struct rb_callinfo *ci, const rb_callable_method_entry_t *cme, rb_iseq_t *block, const int32_t argc, VALUE *known_recv_klass);
 
 // Codegen for rb_obj_not().
 // Note, caller is responsible for generating all the right guards, including
 // arity guards.
 static bool
-jit_rb_obj_not(jitstate_t *jit, ctx_t *ctx, const struct rb_callinfo *ci, const rb_callable_method_entry_t *cme, rb_iseq_t *block, const int32_t argc)
+jit_rb_obj_not(jitstate_t *jit, ctx_t *ctx, const struct rb_callinfo *ci, const rb_callable_method_entry_t *cme, rb_iseq_t *block, const int32_t argc, VALUE *known_recv_klass)
 {
     const val_type_t recv_opnd = ctx_get_opnd_type(ctx, OPND_STACK(0));
 
@@ -2987,7 +2989,7 @@ jit_rb_obj_not(jitstate_t *jit, ctx_t *ctx, const struct rb_callinfo *ci, const 
 
 // Codegen for rb_true()
 static bool
-jit_rb_true(jitstate_t *jit, ctx_t *ctx, const struct rb_callinfo *ci, const rb_callable_method_entry_t *cme, rb_iseq_t *block, const int32_t argc)
+jit_rb_true(jitstate_t *jit, ctx_t *ctx, const struct rb_callinfo *ci, const rb_callable_method_entry_t *cme, rb_iseq_t *block, const int32_t argc, VALUE *known_recv_klass)
 {
     ADD_COMMENT(cb, "nil? == true");
     ctx_stack_pop(ctx, 1);
@@ -2998,7 +3000,7 @@ jit_rb_true(jitstate_t *jit, ctx_t *ctx, const struct rb_callinfo *ci, const rb_
 
 // Codegen for rb_false()
 static bool
-jit_rb_false(jitstate_t *jit, ctx_t *ctx, const struct rb_callinfo *ci, const rb_callable_method_entry_t *cme, rb_iseq_t *block, const int32_t argc)
+jit_rb_false(jitstate_t *jit, ctx_t *ctx, const struct rb_callinfo *ci, const rb_callable_method_entry_t *cme, rb_iseq_t *block, const int32_t argc, VALUE *known_recv_klass)
 {
     ADD_COMMENT(cb, "nil? == false");
     ctx_stack_pop(ctx, 1);
@@ -3010,7 +3012,7 @@ jit_rb_false(jitstate_t *jit, ctx_t *ctx, const struct rb_callinfo *ci, const rb
 // Codegen for rb_obj_equal()
 // object identity comparison
 static bool
-jit_rb_obj_equal(jitstate_t *jit, ctx_t *ctx, const struct rb_callinfo *ci, const rb_callable_method_entry_t *cme, rb_iseq_t *block, const int32_t argc)
+jit_rb_obj_equal(jitstate_t *jit, ctx_t *ctx, const struct rb_callinfo *ci, const rb_callable_method_entry_t *cme, rb_iseq_t *block, const int32_t argc, VALUE *known_recv_klass)
 {
     ADD_COMMENT(cb, "equal?");
     x86opnd_t obj1 = ctx_stack_pop(ctx, 1);
@@ -3027,6 +3029,22 @@ jit_rb_obj_equal(jitstate_t *jit, ctx_t *ctx, const struct rb_callinfo *ci, cons
     return true;
 }
 
+// Codegen for rb_str_to_s()
+// When String#to_s is called on a String instance, the method returns self and most
+// of the overhead comes from setting up the method call. We observed that this situation
+// happens a lot in some workloads.
+static bool
+jit_rb_str_to_s(jitstate_t *jit, ctx_t *ctx, const struct rb_callinfo *ci, const rb_callable_method_entry_t *cme, rb_iseq_t *block, const int32_t argc, VALUE *recv_known_klass)
+{
+    if (recv_known_klass && *recv_known_klass == rb_cString) {
+        ADD_COMMENT(cb, "to_s on plain string");
+        // The method returns the receiver, which is already on the stack.
+        // No stack movement.
+        return true;
+    }
+    return false;
+}
+
 // Check if we know how to codegen for a particular cfunc method
 static method_codegen_t
 lookup_cfunc_codegen(const rb_method_definition_t *def)
@@ -3039,7 +3057,7 @@ lookup_cfunc_codegen(const rb_method_definition_t *def)
 }
 
 static codegen_status_t
-gen_send_cfunc(jitstate_t *jit, ctx_t *ctx, const struct rb_callinfo *ci, const rb_callable_method_entry_t *cme, rb_iseq_t *block, const int32_t argc)
+gen_send_cfunc(jitstate_t *jit, ctx_t *ctx, const struct rb_callinfo *ci, const rb_callable_method_entry_t *cme, rb_iseq_t *block, const int32_t argc, VALUE *recv_known_klass)
 {
     const rb_method_cfunc_t *cfunc = UNALIGNED_MEMBER_PTR(cme->def, body.cfunc);
 
@@ -3084,7 +3102,7 @@ gen_send_cfunc(jitstate_t *jit, ctx_t *ctx, const struct rb_callinfo *ci, const 
     {
         method_codegen_t known_cfunc_codegen;
         if ((known_cfunc_codegen = lookup_cfunc_codegen(cme->def))) {
-            if (known_cfunc_codegen(jit, ctx, ci, cme, block, argc)) {
+            if (known_cfunc_codegen(jit, ctx, ci, cme, block, argc, recv_known_klass)) {
                 // cfunc codegen generated code. Terminate the block so
                 // there isn't multiple calls in the same block.
                 jit_jump_to_next_insn(jit, ctx);
@@ -3643,7 +3661,7 @@ gen_send_general(jitstate_t *jit, ctx_t *ctx, struct rb_call_data *cd, rb_iseq_t
         case VM_METHOD_TYPE_ISEQ:
             return gen_send_iseq(jit, ctx, ci, cme, block, argc);
         case VM_METHOD_TYPE_CFUNC:
-            return gen_send_cfunc(jit, ctx, ci, cme, block, argc);
+            return gen_send_cfunc(jit, ctx, ci, cme, block, argc, &comptime_recv_klass);
         case VM_METHOD_TYPE_IVAR:
             if (argc != 0) {
                 // Argument count mismatch. Getters take no arguments.
@@ -3841,7 +3859,7 @@ gen_invokesuper(jitstate_t* jit, ctx_t* ctx, codeblock_t* cb)
         case VM_METHOD_TYPE_ISEQ:
             return gen_send_iseq(jit, ctx, ci, cme, block, argc);
         case VM_METHOD_TYPE_CFUNC:
-            return gen_send_cfunc(jit, ctx, ci, cme, block, argc);
+            return gen_send_cfunc(jit, ctx, ci, cme, block, argc, NULL);
         default:
             break;
     }
@@ -4479,4 +4497,6 @@ yjit_init_codegen(void)
     yjit_reg_method(rb_cModule, "==", jit_rb_obj_equal);
     yjit_reg_method(rb_cSymbol, "==", jit_rb_obj_equal);
     yjit_reg_method(rb_cSymbol, "===", jit_rb_obj_equal);
+
+    yjit_reg_method(rb_cString, "to_s", jit_rb_str_to_s);
 }

--- a/yjit_codegen.c
+++ b/yjit_codegen.c
@@ -4504,5 +4504,7 @@ yjit_init_codegen(void)
     yjit_reg_method(rb_cSymbol, "==", jit_rb_obj_equal);
     yjit_reg_method(rb_cSymbol, "===", jit_rb_obj_equal);
 
+    // rb_str_to_s() methods in string.c
     yjit_reg_method(rb_cString, "to_s", jit_rb_str_to_s);
+    yjit_reg_method(rb_cString, "to_str", jit_rb_str_to_s);
 }


### PR DESCRIPTION
When calling "to_s" on an instance of String, the method simply returns
self. In this situation most of the work comes from setting up the
method call. It turns out that both railsbench and liquid-render do this
a lot.

When generating code for opt_send_without_block, we already generate a
known class guard, so we can detect when the receiver is a String
instance. Since gen_send_cfunc() is also used for gen_invokesuper(), and
gen_invokesuper() doesn't generate a known class guard, a new nullable
parameter for specialized codegen function is added.

Closes GH-245