### PR TITLE
Add optimized Thread.current

### DIFF
--- a/yjit_codegen.c
+++ b/yjit_codegen.c
@@ -3052,6 +3052,23 @@ jit_rb_str_to_s(jitstate_t *jit, ctx_t *ctx, const struct rb_callinfo *ci, const
     return false;
 }
 
+static bool
+jit_thread_s_current(jitstate_t *jit, ctx_t *ctx, const struct rb_callinfo *ci, const rb_callable_method_entry_t *cme, rb_iseq_t *block, const int32_t argc, VALUE *recv_known_klass)
+{
+    ADD_COMMENT(cb, "Thread.current");
+    ctx_stack_pop(ctx, 1);
+
+    // ec->thread_ptr
+    mov(cb, REG0, member_opnd(REG_EC, rb_execution_context_t, thread_ptr));
+
+    // thread->self
+    mov(cb, REG0, member_opnd(REG0, rb_thread_t, self));
+
+    x86opnd_t stack_ret = ctx_stack_push(ctx, TYPE_HEAP);
+    mov(cb, stack_ret, REG0);
+    return true;
+}
+
 // Check if we know how to codegen for a particular cfunc method
 static method_codegen_t
 lookup_cfunc_codegen(const rb_method_definition_t *def)
@@ -4492,4 +4509,7 @@ yjit_init_codegen(void)
     // rb_str_to_s() methods in string.c
     yjit_reg_method(rb_cString, "to_s", jit_rb_str_to_s);
     yjit_reg_method(rb_cString, "to_str", jit_rb_str_to_s);
+
+    // Thread.current
+    yjit_reg_method(rb_singleton_class(rb_cThread), "current", jit_thread_s_current);
 }


### PR DESCRIPTION
With this `Thread.current` compiles into:

```
== BLOCK 1/4: 13 BYTES, ISEQ RANGE [0,3) =======================================
  ; opt_getinlinecache
  55e13a847d9d:  movabs rax, 0x7f81caaacdc0
  55e13a847da7:  mov    qword ptr [rbx], rax
== BLOCK 2/4: 0 BYTES, ISEQ RANGE [9,11) =======================================
== BLOCK 3/4: 34 BYTES, ISEQ RANGE [9,11) ======================================
  ; opt_send_without_block
  55e13a847daa:  mov    rax, qword ptr [rbx]
  ; guard known object with singleton class
  55e13a847dad:  movabs rcx, 0x7f81caaacdc0
  55e13a847db7:  cmp    rax, rcx
  55e13a847dba:  jne    0x55e1428450cf
  ; Thread.current
  55e13a847dc0:  mov    rax, qword ptr [r12 + 0x30]
  55e13a847dc5:  mov    rax, qword ptr [rax + 0x10]
  55e13a847dc9:  mov    qword ptr [rbx], rax
```

Fixes #251 