### PR TITLE
Add counted side exit to getblockparamproxy

### DIFF
--- a/yjit_codegen.c
+++ b/yjit_codegen.c
@@ -4191,7 +4191,7 @@ gen_getblockparamproxy(jitstate_t *jit, ctx_t *ctx, codeblock_t *cb)
 
     // Bail when VM_ENV_FLAGS(ep, VM_FRAME_FLAG_MODIFIED_BLOCK_PARAM) is non zero
     test(cb, mem_opnd(64, REG0, SIZEOF_VALUE * VM_ENV_DATA_INDEX_FLAGS), imm_opnd(VM_FRAME_FLAG_MODIFIED_BLOCK_PARAM));
-    jnz_ptr(cb, side_exit);
+    jnz_ptr(cb, COUNTED_EXIT(side_exit, block_param_is_modified));
 
     // Load the block handler for the current frame
     // note, VM_ASSERT(VM_ENV_LOCAL_P(ep))
@@ -4202,7 +4202,7 @@ gen_getblockparamproxy(jitstate_t *jit, ctx_t *ctx, codeblock_t *cb)
 
     // Bail unless VM_BH_ISEQ_BLOCK_P(bh). This also checks for null.
     cmp(cb, REG0_8, imm_opnd(0x1));
-    jne_ptr(cb, side_exit);
+    jnz_ptr(cb, COUNTED_EXIT(side_exit, block_handler_is_not_iseq));
 
     // Push rb_block_param_proxy. It's a root, so no need to use jit_mov_gc_ptr.
     mov(cb, REG0, const_ptr_opnd((void *)rb_block_param_proxy));

--- a/yjit_iface.h
+++ b/yjit_iface.h
@@ -107,6 +107,9 @@ YJIT_DECLARE_COUNTERS(
     expandarray_not_array,
     expandarray_rhs_too_small,
 
+    block_param_is_modified,
+    block_handler_is_not_iseq,
+
     // Member with known name for iterating over counters
     last_member
 )


### PR DESCRIPTION
This is so we know the specific reason we're exiting this instruction.

Co-authored-by: Aaron Patterson tenderlove@ruby-lang.org