### PR TITLE
Fix counter names for getblockparamproxy. Print in --yjit-stats.

### DIFF
--- a/yjit.rb
+++ b/yjit.rb
@@ -155,6 +155,7 @@ module YJIT
       print_counters(stats, prefix: 'send_', prompt: 'method call exit reasons: ')
       print_counters(stats, prefix: 'invokesuper_', prompt: 'invokesuper exit reasons: ')
       print_counters(stats, prefix: 'leave_', prompt: 'leave exit reasons: ')
+      print_counters(stats, prefix: 'gbpp_', prompt: 'getblockparamproxy exit reasons: ')
       print_counters(stats, prefix: 'getivar_', prompt: 'getinstancevariable exit reasons:')
       print_counters(stats, prefix: 'setivar_', prompt: 'setinstancevariable exit reasons:')
       print_counters(stats, prefix: 'oaref_', prompt: 'opt_aref exit reasons: ')

--- a/yjit_codegen.c
+++ b/yjit_codegen.c
@@ -4217,7 +4217,7 @@ gen_getblockparamproxy(jitstate_t *jit, ctx_t *ctx, codeblock_t *cb)
 
     // Bail when VM_ENV_FLAGS(ep, VM_FRAME_FLAG_MODIFIED_BLOCK_PARAM) is non zero
     test(cb, mem_opnd(64, REG0, SIZEOF_VALUE * VM_ENV_DATA_INDEX_FLAGS), imm_opnd(VM_FRAME_FLAG_MODIFIED_BLOCK_PARAM));
-    jnz_ptr(cb, COUNTED_EXIT(side_exit, block_param_is_modified));
+    jnz_ptr(cb, COUNTED_EXIT(side_exit, gbpp_block_param_modified));
 
     // Load the block handler for the current frame
     // note, VM_ASSERT(VM_ENV_LOCAL_P(ep))
@@ -4228,7 +4228,7 @@ gen_getblockparamproxy(jitstate_t *jit, ctx_t *ctx, codeblock_t *cb)
 
     // Bail unless VM_BH_ISEQ_BLOCK_P(bh). This also checks for null.
     cmp(cb, REG0_8, imm_opnd(0x1));
-    jnz_ptr(cb, COUNTED_EXIT(side_exit, block_handler_is_not_iseq));
+    jnz_ptr(cb, COUNTED_EXIT(side_exit, gbpp_block_handler_not_iseq));
 
     // Push rb_block_param_proxy. It's a root, so no need to use jit_mov_gc_ptr.
     mov(cb, REG0, const_ptr_opnd((void *)rb_block_param_proxy));

--- a/yjit_iface.h
+++ b/yjit_iface.h
@@ -107,8 +107,8 @@ YJIT_DECLARE_COUNTERS(
     expandarray_not_array,
     expandarray_rhs_too_small,
 
-    block_param_is_modified,
-    block_handler_is_not_iseq,
+    gbpp_block_param_modified,
+    gbpp_block_handler_not_iseq,
 
     // Member with known name for iterating over counters
     last_member


### PR DESCRIPTION
@tenderlove was missing the printing in `YJIT.rb` so we can see the counters in `--yjit-stats`.