### PR TITLE
Add comments about special runtime routines YJIT calls

### DIFF
--- a/internal/array.h
+++ b/internal/array.h
@@ -46,6 +46,7 @@ struct rb_execution_context_struct;
 VALUE rb_ec_ary_new_from_values(struct rb_execution_context_struct *ec, long n, const VALUE *elts);
 MJIT_SYMBOL_EXPORT_END
 
+// YJIT needs this function to never allocate and never raise
 static inline VALUE
 rb_ary_entry_internal(VALUE ary, long offset)
 {

--- a/internal/string.h
+++ b/internal/string.h
@@ -116,6 +116,7 @@ is_broken_string(VALUE str)
 }
 
 /* expect tail call optimization */
+// YJIT needs this function to never allocate and never raise
 static inline VALUE
 rb_str_eql_internal(const VALUE str1, const VALUE str2)
 {

--- a/object.c
+++ b/object.c
@@ -790,6 +790,8 @@ rb_obj_is_kind_of(VALUE obj, VALUE c)
 {
     VALUE cl = CLASS_OF(obj);
 
+    // Note: YJIT needs this function to never allocate and never raise when
+    // `c` is a class or a module.
     c = class_or_module_required(c);
     return RBOOL(class_search_ancestor(cl, RCLASS_ORIGIN(c)));
 }

--- a/vm_core.h
+++ b/vm_core.h
@@ -446,6 +446,8 @@ struct rb_iseq_constant_body {
     char catch_except_p; /* If a frame of this ISeq may catch exception, set TRUE */
     // If true, this ISeq is leaf *and* backtraces are not used, for example,
     // by rb_profile_frames. We verify only leafness on VM_CHECK_MODE though.
+    // Note that GC allocations might use backtraces due to
+    // ObjectSpace#trace_object_allocations.
     // For more details, see: https://bugs.ruby-lang.org/issues/16956
     bool builtin_inline_p;
     struct rb_id_table *outer_variables;

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -4788,6 +4788,7 @@ vm_ic_hit_p(const struct iseq_inline_constant_cache_entry *ice, const VALUE *reg
     return vm_inlined_ic_hit_p(ice->flags, ice->value, ice->ic_cref, ice->ic_serial, reg_ep);
 }
 
+// YJIT needs this function to never allocate and never raise
 bool
 rb_vm_ic_hit_p(IC ic, const VALUE *reg_ep)
 {


### PR DESCRIPTION
When YJIT make calls to routines without reconstructing interpreter
state through jit_prepare_routine_call(), it relies on the routine to
never allocate, raise, and push/pop control frames. Comment about this
on the routines that YJTI calls.

This is probably something we should dynamically verify on debug builds.
It's hard to statically verify this as it requires verifying all
functions in the call tree. Maybe something to look at in the future.