### PR TITLE
Extract yjit_force_iv_index and make it work when object is frozen

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -2160,3 +2160,18 @@ assert_equal '[2]', %q{
 
   5.times.map { default_expression(value: 2) }.uniq
 }
+
+# attr_reader on frozen object
+assert_equal 'false', %q{
+  class Foo
+    attr_reader :exception
+
+    def failed?
+      !exception.nil?
+    end
+  end
+
+  foo = Foo.new.freeze
+  foo.failed?
+  foo.failed?
+}

--- a/internal/variable.h
+++ b/internal/variable.h
@@ -35,6 +35,7 @@ void rb_gvar_ractor_local(const char *name);
 static inline bool ROBJ_TRANSIENT_P(VALUE obj);
 static inline void ROBJ_TRANSIENT_SET(VALUE obj);
 static inline void ROBJ_TRANSIENT_UNSET(VALUE obj);
+uint32_t rb_obj_ensure_iv_index_mapping(VALUE obj, ID id);
 
 RUBY_SYMBOL_EXPORT_BEGIN
 /* variable.c (export) */

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -1103,12 +1103,6 @@ iv_index_tbl_lookup(struct st_table *iv_index_tbl, ID id, struct rb_iv_index_tbl
     return found ? true : false;
 }
 
-bool
-rb_iv_index_tbl_lookup(struct st_table *iv_index_tbl, ID id, struct rb_iv_index_tbl_entry **ent)
-{
-    return iv_index_tbl_lookup(iv_index_tbl, id, ent);
-}
-
 ALWAYS_INLINE(static void fill_ivar_cache(const rb_iseq_t *iseq, IVC ic, const struct rb_callcache *cc, int is_attr, struct rb_iv_index_tbl_entry *ent));
 
 static inline void


### PR DESCRIPTION
In an effort to simplify the logic YJIT generates for accessing instance
variable, YJIT ensures that a given name-to-index mapping exists at
compile time. In the case that the mapping doesn't exist, it was created
by using rb_ivar_set() with Qundef on the sample object we see at
compile time. This hack isn't fine if the sample object happens to be
frozen, in which case YJIT would raise a FrozenError unexpectedly.

To deal with this, make a new function that only reserves the mapping
but doesn't touch the object. This is rb_obj_ensure_iv_index_mapping().
This new function superceeds the functionality of rb_iv_index_tbl_lookup()
so it was removed.

Reported by and includes a test case from John Hawthorn <john@hawthorn.email>

Fixes: GH-282