### PR TITLE
Fix non RUBY_DEBUG build warnings

### DIFF
--- a/yjit_asm.c
+++ b/yjit_asm.c
@@ -78,7 +78,7 @@ x86opnd_t mem_opnd_sib(uint32_t num_bits, x86opnd_t base_reg, x86opnd_t index_re
         scale_exp = 0;
         break;
       default:
-        assert(false && "scale not one of 1,2,4,8");
+        rb_bug("yjit: scale not one of 1,2,4,8");
         break;
     }
 
@@ -466,7 +466,7 @@ static bool rex_needed(x86opnd_t opnd)
         return (opnd.as.mem.base_reg_no > 7) || (opnd.as.mem.has_idx && opnd.as.mem.idx_reg_no > 7);
     }
 
-    assert (false);
+    rb_bug("unreachable");
 }
 
 // Check if an SIB byte is needed to encode this operand
@@ -643,7 +643,7 @@ static void cb_write_rm(
         else if (dsize == 32)
             mod = 2;
         else
-            assert (false);
+            rb_bug("unreachable");
     }
 
     // Encode the reg field
@@ -726,7 +726,7 @@ static void write_rm_unary(
     if (opnd.type == OPND_REG || opnd.type == OPND_MEM)
         opndSize = opnd.num_bits;
     else
-        assert (false && "invalid operand");
+        rb_bug("yjit: invalid operand");
 
     assert (opndSize == 8 || opndSize == 16 || opndSize == 32 || opndSize == 64);
     bool szPref = opndSize == 16;
@@ -856,7 +856,7 @@ static void cb_write_shift(
     if (opnd0.type == OPND_REG || opnd0.type == OPND_MEM)
         opndSize = opnd0.num_bits;
     else
-        assert (false && "shift: invalid first operand");
+        rb_bug("yjit: shift: invalid first operand");
 
     assert (opndSize == 16 || opndSize == 32 || opndSize == 64);
     bool szPref = opndSize == 16;

--- a/yjit_codegen.c
+++ b/yjit_codegen.c
@@ -1455,7 +1455,7 @@ jit_chain_guard(enum jcc_kinds jcc, jitstate_t *jit, const ctx_t *ctx, uint8_t d
         target0_gen_fn = gen_jbe_to_target0;
         break;
       default:
-        RUBY_ASSERT(false && "unimplemented jump kind");
+        rb_bug("yjit: unimplemented jump kind");
         break;
     };
 

--- a/yjit_iface.h
+++ b/yjit_iface.h
@@ -22,8 +22,10 @@ static VALUE *yjit_iseq_pc_at_idx(const rb_iseq_t *iseq, uint32_t insn_idx);
 static int yjit_opcode_at_pc(const rb_iseq_t *iseq, const VALUE *pc);
 static void yjit_print_iseq(const rb_iseq_t *iseq);
 
+#if YJIT_STATS
 // this function *must* return passed exit_pc
 static const VALUE *yjit_count_side_exit_op(const VALUE *exit_pc);
+#endif
 
 static void yjit_unlink_method_lookup_dependency(block_t *block);
 static void yjit_block_assumptions_free(block_t *block);


### PR DESCRIPTION
On non RUBY_DEBUG builds, assert() compiles to nothing and the compiler
warns about uninitialized variables in those code paths. Replace
those asserts with rb_bug() to fix the warnings and do the assert in
all builds.

Also put YJIT_STATS check for function delcaration that is only defined
in YJIT_STATS builds.